### PR TITLE
Add Android companion and fix Termux startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v
+
+  frontend-build:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build-frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,30 @@ jobs:
 
       - name: Build frontend
         run: npm run build-frontend
+
+  android-build:
+    name: Android companion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install Android SDK packages
+        run: sdkmanager "platforms;android-29" "build-tools;35.0.1"
+
+      - name: Build Android APK
+        run: ./android/build-apk.sh
+
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: crosstalk-android-debug
+          path: android/build/Crosstalk-Android.apk
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__/
 /dist/
 /public/
 /electron/build/exe/
+/android/build/
 
 # local storage
 storage/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Open <http://localhost:8000>. Run `python3 crosstalk.py --help` for server, iden
 python3 -m pip install -r requirements.txt
 npm install
 npm run build-frontend
+python3 -m unittest discover -s tests -v
 python3 crosstalk.py --headless
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Other supported setups:
 
 - [Docker](./docs/crosstalk_on_docker.md)
 - [Raspberry Pi](./docs/crosstalk_on_raspberry_pi.md)
-- [Android with Termux](./docs/crosstalk_on_android_with_termux.md)
+- [Android companion + Termux](./android/README.md)
+- [Android with Termux (manual browser setup)](./docs/crosstalk_on_android_with_termux.md)
 
 To run from source, install Python 3 and Node.js 22.12 or newer, then:
 

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.buildwithparallel.crosstalk"
+    android:versionCode="1"
+    android:versionName="0.1.0">
+
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="29" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+
+    <application
+        android:allowBackup="false"
+        android:hardwareAccelerated="true"
+        android:icon="@drawable/ic_crosstalk"
+        android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".CrosstalkActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,61 @@
+# Crosstalk for Android
+
+The Android companion provides a native, OLED-friendly shell for a Crosstalk
+backend running locally in Termux. The WebView is restricted to
+`http://localhost:8000`; normal HTTP links leave the app and cleartext traffic
+to non-local hosts is blocked by Android's network security policy.
+
+The Python/Reticulum backend remains in Termux instead of being duplicated in
+the APK. This keeps one identity and database, preserves the normal interface
+configuration, and avoids shipping a second Python runtime.
+
+## Install the Termux backend
+
+Follow [Crosstalk on Android](../docs/crosstalk_on_android_with_termux.md), then
+install the fixed controller command:
+
+```sh
+install -m 700 android/termux/crosstalk-android-server \
+  "$PREFIX/bin/crosstalk-android-server"
+```
+
+The controller searches `$HOME/apps/crosstalk` and `$HOME/crosstalk`. Set
+`CROSSTALK_HOME` before launching it when the checkout lives elsewhere. It
+stores identity and application data under `$HOME/.local/share/crosstalk` by
+default and binds the UI/API only to loopback.
+
+To let the Android companion invoke this one fixed controller, add the
+following to `~/.termux/termux.properties` and restart Termux:
+
+```properties
+allow-external-apps=true
+```
+
+Android will still require the user to grant Crosstalk the Termux
+`RUN_COMMAND` permission. The app cannot execute arbitrary commands: it calls
+only `$PREFIX/bin/crosstalk-android-server start`.
+
+## Build the APK
+
+The build has no Gradle or third-party Android dependencies. It requires JDK 8+
+and Android SDK platform 29 with build-tools 35.0.1:
+
+```sh
+./android/build-apk.sh
+adb install -r android/build/Crosstalk-Android.apk
+```
+
+The generated APK is debug-signed for development. Published releases should
+use a project-owned signing key and verify the APK digest before installation.
+
+## Privacy boundary
+
+- The backend listens on `127.0.0.1:8000`, not Wi-Fi or a public interface.
+- The WebView accepts navigation only within the local Crosstalk origin.
+- External HTTP(S) links open in the user's normal browser.
+- File access is disabled inside the WebView; attachments use Android's system
+  document picker.
+- Microphone access is requested only when the local Crosstalk origin asks for
+  audio capture.
+- Android backups are disabled for the companion. Reticulum identity material
+  remains in Termux storage and is never copied into the APK.

--- a/android/build-apk.sh
+++ b/android/build-apk.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+sdk_dir=${ANDROID_SDK_ROOT:-"$HOME/Library/Android/sdk"}
+platform=${ANDROID_PLATFORM:-android-29}
+build_tools_version=${ANDROID_BUILD_TOOLS:-35.0.1}
+android_jar="$sdk_dir/platforms/$platform/android.jar"
+build_tools="$sdk_dir/build-tools/$build_tools_version"
+output_apk=${OUTPUT_APK:-"$project_dir/build/Crosstalk-Android.apk"}
+keystore=${ANDROID_DEBUG_KEYSTORE:-"$HOME/.android/debug.keystore"}
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+[ -r "$android_jar" ] || { printf 'Missing %s\n' "$android_jar" >&2; exit 1; }
+for tool in aapt2 d8 zipalign apksigner; do
+    [ -x "$build_tools/$tool" ] || { printf 'Missing build tool: %s\n' "$build_tools/$tool" >&2; exit 1; }
+done
+
+mkdir -p "$work_dir/classes" "$work_dir/dex" "$work_dir/generated" "$(dirname -- "$output_apk")"
+"$build_tools/aapt2" compile --dir "$project_dir/res" -o "$work_dir/resources.zip"
+"$build_tools/aapt2" link -o "$work_dir/unsigned.apk" -I "$android_jar" \
+    --manifest "$project_dir/AndroidManifest.xml" --min-sdk-version 26 --target-sdk-version 29 \
+    --auto-add-overlay -R "$work_dir/resources.zip" --java "$work_dir/generated"
+find "$project_dir/src" "$work_dir/generated" -name '*.java' -print0 | \
+    xargs -0 javac --release 8 -classpath "$android_jar" -d "$work_dir/classes"
+"$build_tools/d8" --lib "$android_jar" --min-api 26 --output "$work_dir/dex" \
+    $(find "$work_dir/classes" -name '*.class' -print)
+zip -q -j "$work_dir/unsigned.apk" "$work_dir/dex/classes.dex"
+"$build_tools/zipalign" -f 4 "$work_dir/unsigned.apk" "$work_dir/aligned.apk"
+
+if [ ! -r "$keystore" ]; then
+    mkdir -p "$(dirname -- "$keystore")"
+    keytool -genkeypair -keystore "$keystore" -storepass android -keypass android \
+        -alias androiddebugkey -dname "CN=Android Debug,O=Android,C=US" \
+        -keyalg RSA -keysize 2048 -validity 10000 >/dev/null 2>&1
+fi
+"$build_tools/apksigner" sign --ks "$keystore" --ks-pass pass:android --key-pass pass:android \
+    --out "$output_apk" "$work_dir/aligned.apk"
+"$build_tools/apksigner" verify --verbose "$output_apk"
+printf '%s\n' "$output_apk"

--- a/android/res/drawable/ic_crosstalk.xml
+++ b/android/res/drawable/ic_crosstalk.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path android:fillColor="#090D16" android:pathData="M8,4h32a4,4 0,0 1,4 4v32a4,4 0,0 1,-4 4h-32a4,4 0,0 1,-4 -4v-32a4,4 0,0 1,4 -4z" />
+    <path android:fillColor="#00000000" android:strokeColor="#2F7FFF" android:strokeWidth="2.2" android:strokeLineJoin="round" android:pathData="M14,12h20a4,4 0,0 1,4 4v13a4,4 0,0 1,-4 4h-9l-6,5v-5h-5a4,4 0,0 1,-4 -4v-13a4,4 0,0 1,4 -4z" />
+    <path android:fillColor="#00000000" android:strokeColor="#6EA8FF" android:strokeWidth="1.4" android:pathData="M17,22L24,17L31,21L23,28L17,22M24,17L23,28L32,28" />
+    <path android:fillColor="#6EA8FF" android:pathData="M24,15a2,2 0,1 0,0 4a2,2 0,1 0,0 -4M17,20a2,2 0,1 0,0 4a2,2 0,1 0,0 -4M31,19a2,2 0,1 0,0 4a2,2 0,1 0,0 -4M23,26a2,2 0,1 0,0 4a2,2 0,1 0,0 -4M32,26a2,2 0,1 0,0 4a2,2 0,1 0,0 -4" />
+</vector>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Crosstalk</string>
+</resources>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="android:windowBackground">#000000</item>
+        <item name="android:colorAccent">#2F7FFF</item>
+        <item name="android:navigationBarColor">#000000</item>
+        <item name="android:statusBarColor">#000000</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>

--- a/android/res/xml/network_security_config.xml
+++ b/android/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/android/src/com/buildwithparallel/crosstalk/CrosstalkActivity.java
+++ b/android/src/com/buildwithparallel/crosstalk/CrosstalkActivity.java
@@ -1,0 +1,448 @@
+package com.buildwithparallel.crosstalk;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.PermissionRequest;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public final class CrosstalkActivity extends Activity {
+    private static final String LOCAL_ORIGIN = "http://localhost:8000";
+    private static final String STATUS_URL = LOCAL_ORIGIN + "/api/v1/status";
+    private static final String TERMUX_PACKAGE = "com.termux";
+    private static final String TERMUX_PERMISSION = "com.termux.permission.RUN_COMMAND";
+    private static final String TERMUX_RUNNER = "/data/data/com.termux/files/usr/bin/crosstalk-android-server";
+    private static final int REQUEST_TERMUX = 1001;
+    private static final int REQUEST_AUDIO = 1002;
+    private static final int REQUEST_FILE = 1003;
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private WebView webView;
+    private TextView status;
+    private TextView offlineMessage;
+    private LinearLayout offlinePanel;
+    private ValueCallback<Uri[]> fileCallback;
+    private PermissionRequest audioPermissionRequest;
+    private int probeGeneration;
+
+    @Override protected void onCreate(Bundle state) {
+        super.onCreate(state);
+        getWindow().setStatusBarColor(Color.BLACK);
+        getWindow().setNavigationBarColor(Color.BLACK);
+        WebView.setWebContentsDebuggingEnabled(false);
+        setContentView(createContent());
+        configureWebView();
+        probeBackend(true);
+    }
+
+    private View createContent() {
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setBackgroundColor(Color.BLACK);
+
+        LinearLayout toolbar = new LinearLayout(this);
+        toolbar.setOrientation(LinearLayout.HORIZONTAL);
+        toolbar.setGravity(Gravity.CENTER_VERTICAL);
+        toolbar.setPadding(dp(16), 0, dp(12), 0);
+        toolbar.setBackgroundColor(Color.rgb(5, 7, 12));
+        root.addView(toolbar, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dp(48)));
+
+        TextView title = new TextView(this);
+        title.setText("CROSSTALK");
+        title.setTextColor(Color.WHITE);
+        title.setTextSize(15);
+        title.setLetterSpacing(0.12f);
+        title.setGravity(Gravity.CENTER_VERTICAL);
+        toolbar.addView(title, new LinearLayout.LayoutParams(0,
+                ViewGroup.LayoutParams.MATCH_PARENT, 1f));
+
+        status = new TextView(this);
+        status.setText("CHECKING");
+        status.setTextColor(Color.rgb(110, 168, 255));
+        status.setTextSize(11);
+        status.setGravity(Gravity.CENTER);
+        status.setPadding(dp(10), 0, dp(10), 0);
+        status.setBackground(rounded(Color.rgb(10, 20, 38), Color.rgb(35, 76, 132), 14));
+        toolbar.addView(status, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, dp(28)));
+
+        FrameLayout content = new FrameLayout(this);
+        root.addView(content, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+
+        webView = new WebView(this);
+        webView.setBackgroundColor(Color.BLACK);
+        content.addView(webView, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+        offlinePanel = new LinearLayout(this);
+        offlinePanel.setOrientation(LinearLayout.VERTICAL);
+        offlinePanel.setGravity(Gravity.CENTER);
+        offlinePanel.setPadding(dp(28), dp(28), dp(28), dp(28));
+        offlinePanel.setBackgroundColor(Color.BLACK);
+        content.addView(offlinePanel, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+        TextView heading = new TextView(this);
+        heading.setText("LOCAL NODE OFFLINE");
+        heading.setTextColor(Color.WHITE);
+        heading.setTextSize(20);
+        heading.setLetterSpacing(0.08f);
+        heading.setGravity(Gravity.CENTER);
+        offlinePanel.addView(heading, matchWrap(dp(12)));
+
+        offlineMessage = new TextView(this);
+        offlineMessage.setText("Waiting for the Crosstalk backend on localhost:8000.");
+        offlineMessage.setTextColor(Color.rgb(165, 175, 194));
+        offlineMessage.setTextSize(14);
+        offlineMessage.setGravity(Gravity.CENTER);
+        offlinePanel.addView(offlineMessage, matchWrap(dp(24)));
+
+        Button start = actionButton("START LOCAL BACKEND", true);
+        start.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) { requestBackendStart(); }
+        });
+        offlinePanel.addView(start, matchButton());
+
+        Button retry = actionButton("RETRY", false);
+        retry.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) { probeBackend(false); }
+        });
+        offlinePanel.addView(retry, matchButton());
+
+        Button setup = actionButton("OPEN TERMUX", false);
+        setup.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) { openTermux(); }
+        });
+        offlinePanel.addView(setup, matchButton());
+
+        return root;
+    }
+
+    private LinearLayout.LayoutParams matchWrap(int bottomMargin) {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.bottomMargin = bottomMargin;
+        return params;
+    }
+
+    private LinearLayout.LayoutParams matchButton() {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dp(48));
+        params.topMargin = dp(8);
+        return params;
+    }
+
+    private Button actionButton(String text, boolean primary) {
+        Button button = new Button(this);
+        button.setText(text);
+        button.setTextSize(12);
+        button.setTextColor(primary ? Color.WHITE : Color.rgb(150, 183, 235));
+        button.setAllCaps(false);
+        button.setBackground(rounded(primary ? Color.rgb(0, 97, 253) : Color.rgb(7, 13, 24),
+                primary ? Color.rgb(0, 97, 253) : Color.rgb(35, 51, 80), 12));
+        return button;
+    }
+
+    private GradientDrawable rounded(int fill, int stroke, int radiusDp) {
+        GradientDrawable value = new GradientDrawable();
+        value.setColor(fill);
+        value.setCornerRadius(dp(radiusDp));
+        value.setStroke(dp(1), stroke);
+        return value;
+    }
+
+    private void configureWebView() {
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setDatabaseEnabled(false);
+        settings.setAllowFileAccess(false);
+        settings.setAllowContentAccess(true);
+        settings.setMediaPlaybackRequiresUserGesture(false);
+        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
+        settings.setCacheMode(WebSettings.LOAD_DEFAULT);
+        settings.setBuiltInZoomControls(false);
+        settings.setDisplayZoomControls(false);
+        if (android.os.Build.VERSION.SDK_INT >= 26) settings.setSafeBrowsingEnabled(true);
+
+        webView.setWebViewClient(new WebViewClient() {
+            @Override public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                return routeUrl(request.getUrl());
+            }
+
+            @Override public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                return routeUrl(Uri.parse(url));
+            }
+
+            @Override public void onPageFinished(WebView view, String url) {
+                if (isLocal(url)) setOnline();
+            }
+
+            @Override public void onReceivedError(WebView view, WebResourceRequest request,
+                                                   WebResourceError error) {
+                if (request.isForMainFrame()) showOffline("The local backend stopped responding.");
+            }
+        });
+
+        webView.setWebChromeClient(new WebChromeClient() {
+            @Override public boolean onShowFileChooser(WebView view, ValueCallback<Uri[]> callback,
+                                                        FileChooserParams params) {
+                if (fileCallback != null) fileCallback.onReceiveValue(null);
+                fileCallback = callback;
+                try {
+                    Intent chooser = params.createIntent();
+                    chooser.addCategory(Intent.CATEGORY_OPENABLE);
+                    startActivityForResult(chooser, REQUEST_FILE);
+                    return true;
+                } catch (ActivityNotFoundException error) {
+                    fileCallback = null;
+                    toast("No file picker is available");
+                    return false;
+                }
+            }
+
+            @Override public void onPermissionRequest(final PermissionRequest request) {
+                runOnUiThread(new Runnable() {
+                    @Override public void run() {
+                        if (!isLocal(request.getOrigin().toString()) ||
+                                !contains(request.getResources(), PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
+                            request.deny();
+                            return;
+                        }
+                        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+                            request.grant(new String[]{PermissionRequest.RESOURCE_AUDIO_CAPTURE});
+                        } else {
+                            audioPermissionRequest = request;
+                            requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, REQUEST_AUDIO);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    private boolean contains(String[] values, String wanted) {
+        for (String value : values) if (wanted.equals(value)) return true;
+        return false;
+    }
+
+    private boolean routeUrl(Uri uri) {
+        if (isLocal(uri.toString())) return false;
+        String scheme = uri.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) return true;
+        try { startActivity(new Intent(Intent.ACTION_VIEW, uri)); }
+        catch (ActivityNotFoundException error) { toast("No browser is available"); }
+        return true;
+    }
+
+    private boolean isLocal(String url) {
+        return url != null && (url.equals(LOCAL_ORIGIN) || url.startsWith(LOCAL_ORIGIN + "/") ||
+                url.equals("http://127.0.0.1:8000") || url.startsWith("http://127.0.0.1:8000/"));
+    }
+
+    private void probeBackend(final boolean startWhenOffline) {
+        final int generation = ++probeGeneration;
+        status.setText("CHECKING");
+        new Thread(new Runnable() {
+            @Override public void run() {
+                final boolean online = backendResponds();
+                handler.post(new Runnable() {
+                    @Override public void run() {
+                        if (generation != probeGeneration || isFinishing()) return;
+                        if (online) {
+                            setOnline();
+                            if (!isLocal(webView.getUrl())) webView.loadUrl(LOCAL_ORIGIN);
+                        } else if (startWhenOffline && hasTermuxPermission() && isTermuxInstalled()) {
+                            startBackend();
+                        } else {
+                            showOffline("Waiting for the Crosstalk backend on localhost:8000.");
+                        }
+                    }
+                });
+            }
+        }, "crosstalk-probe").start();
+    }
+
+    private boolean backendResponds() {
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection)new URL(STATUS_URL).openConnection();
+            connection.setConnectTimeout(1200);
+            connection.setReadTimeout(1200);
+            connection.setUseCaches(false);
+            return connection.getResponseCode() == 200;
+        } catch (Exception ignored) {
+            return false;
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    private void requestBackendStart() {
+        if (!isTermuxInstalled()) {
+            showOffline("Termux is required to run the local Python backend.");
+            return;
+        }
+        if (!hasTermuxPermission()) {
+            requestPermissions(new String[]{TERMUX_PERMISSION}, REQUEST_TERMUX);
+            return;
+        }
+        startBackend();
+    }
+
+    private void startBackend() {
+        status.setText("STARTING");
+        offlineMessage.setText("Starting the private localhost backend through Termux…");
+        try {
+            Intent command = new Intent("com.termux.RUN_COMMAND");
+            command.setClassName(TERMUX_PACKAGE, "com.termux.app.RunCommandService");
+            command.putExtra("com.termux.RUN_COMMAND_PATH", TERMUX_RUNNER);
+            command.putExtra("com.termux.RUN_COMMAND_ARGUMENTS", new String[]{"start"});
+            command.putExtra("com.termux.RUN_COMMAND_WORKDIR", "/data/data/com.termux/files/home");
+            command.putExtra("com.termux.RUN_COMMAND_BACKGROUND", true);
+            startService(command);
+            pollUntilReady(0);
+        } catch (RuntimeException error) {
+            showOffline("Termux refused the command. Enable allow-external-apps and install the controller script.");
+        }
+    }
+
+    private void pollUntilReady(final int attempt) {
+        if (attempt >= 20) {
+            showOffline("Backend did not become ready. Open Termux and inspect the Crosstalk log.");
+            return;
+        }
+        handler.postDelayed(new Runnable() {
+            @Override public void run() {
+                new Thread(new Runnable() {
+                    @Override public void run() {
+                        final boolean ready = backendResponds();
+                        handler.post(new Runnable() {
+                            @Override public void run() {
+                                if (ready) {
+                                    setOnline();
+                                    webView.loadUrl(LOCAL_ORIGIN);
+                                } else {
+                                    status.setText("STARTING " + (attempt + 1) + "/20");
+                                    pollUntilReady(attempt + 1);
+                                }
+                            }
+                        });
+                    }
+                }, "crosstalk-start-probe").start();
+            }
+        }, 750L);
+    }
+
+    private void setOnline() {
+        status.setText("LOCAL • ONLINE");
+        offlinePanel.setVisibility(View.GONE);
+        webView.setVisibility(View.VISIBLE);
+    }
+
+    private void showOffline(String message) {
+        status.setText("OFFLINE");
+        offlineMessage.setText(message);
+        webView.setVisibility(View.GONE);
+        offlinePanel.setVisibility(View.VISIBLE);
+    }
+
+    private boolean isTermuxInstalled() {
+        try {
+            getPackageManager().getPackageInfo(TERMUX_PACKAGE, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    private boolean hasTermuxPermission() {
+        return checkSelfPermission(TERMUX_PERMISSION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void openTermux() {
+        Intent intent = getPackageManager().getLaunchIntentForPackage(TERMUX_PACKAGE);
+        if (intent == null) {
+            try { startActivity(new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.parse("package:" + getPackageName()))); }
+            catch (RuntimeException ignored) { toast("Termux is not installed"); }
+            return;
+        }
+        startActivity(intent);
+    }
+
+    @Override public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
+        super.onRequestPermissionsResult(requestCode, permissions, results);
+        boolean granted = results.length > 0 && results[0] == PackageManager.PERMISSION_GRANTED;
+        if (requestCode == REQUEST_TERMUX) {
+            if (granted) startBackend();
+            else showOffline("Grant Crosstalk permission to run its fixed Termux controller command.");
+        } else if (requestCode == REQUEST_AUDIO && audioPermissionRequest != null) {
+            if (granted) audioPermissionRequest.grant(new String[]{PermissionRequest.RESOURCE_AUDIO_CAPTURE});
+            else audioPermissionRequest.deny();
+            audioPermissionRequest = null;
+        }
+    }
+
+    @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != REQUEST_FILE || fileCallback == null) return;
+        Uri[] result = WebChromeClient.FileChooserParams.parseResult(resultCode, data);
+        fileCallback.onReceiveValue(result);
+        fileCallback = null;
+    }
+
+    @Override public void onBackPressed() {
+        if (webView != null && webView.getVisibility() == View.VISIBLE && webView.canGoBack()) webView.goBack();
+        else super.onBackPressed();
+    }
+
+    @Override protected void onDestroy() {
+        probeGeneration++;
+        handler.removeCallbacksAndMessages(null);
+        if (fileCallback != null) fileCallback.onReceiveValue(null);
+        if (audioPermissionRequest != null) audioPermissionRequest.deny();
+        if (webView != null) {
+            webView.stopLoading();
+            webView.destroy();
+        }
+        super.onDestroy();
+    }
+
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+
+    private void toast(String text) {
+        Toast.makeText(this, text, Toast.LENGTH_SHORT).show();
+    }
+}

--- a/android/termux/crosstalk-android-server
+++ b/android/termux/crosstalk-android-server
@@ -1,0 +1,97 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -eu
+
+home=${CROSSTALK_HOME:-}
+if [ -z "$home" ]; then
+    for candidate in "$HOME/apps/crosstalk" "$HOME/crosstalk"; do
+        if [ -r "$candidate/crosstalk.py" ]; then
+            home=$candidate
+            break
+        fi
+    done
+fi
+
+data=${CROSSTALK_STORAGE_DIR:-"$HOME/.local/share/crosstalk"}
+runtime=${CROSSTALK_RUNTIME_DIR:-"$HOME/.cache"}
+pidfile="$runtime/crosstalk.pid"
+log="$runtime/crosstalk.log"
+url=http://127.0.0.1:8000
+
+find_python() {
+    for candidate in "$home/.venv/bin/python" "$HOME/.venvs/crosstalk/bin/python" "$PREFIX/bin/python"; do
+        if [ -x "$candidate" ]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+running_pid() {
+    pid=$(sed -n '1p' "$pidfile" 2>/dev/null || printf 0)
+    case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$pid" -gt 1 ] && kill -0 "$pid" 2>/dev/null || return 1
+    tr '\000' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -Fq "$home/crosstalk.py" || return 1
+    printf '%s' "$pid"
+}
+
+start_server() {
+    if pid=$(running_pid); then
+        printf 'Crosstalk already running (pid %s)\n%s\n' "$pid" "$url"
+        return 0
+    fi
+    [ -n "$home" ] && [ -r "$home/crosstalk.py" ] || {
+        printf 'Crosstalk source not found; set CROSSTALK_HOME\n' >&2
+        return 1
+    }
+    python=$(find_python) || {
+        printf 'Crosstalk Python environment not found\n' >&2
+        return 1
+    }
+    mkdir -p "$data" "$runtime"
+    cd "$home"
+    nohup "$python" "$home/crosstalk.py" --headless --host 127.0.0.1 --port 8000 \
+        --storage-dir "$data" >>"$log" 2>&1 </dev/null &
+    pid=$!
+    printf '%s\n' "$pid" > "$pidfile"
+    attempt=0
+    while [ "$attempt" -lt 20 ]; do
+        if curl -fsS --max-time 2 "$url/api/v1/status" >/dev/null 2>&1; then
+            printf 'Crosstalk ready (pid %s)\n%s\n' "$pid" "$url"
+            return 0
+        fi
+        kill -0 "$pid" 2>/dev/null || break
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+    printf 'Crosstalk failed to start; inspect %s\n' "$log" >&2
+    return 1
+}
+
+stop_server() {
+    if ! pid=$(running_pid); then
+        rm -f "$pidfile"
+        printf 'Crosstalk is stopped\n'
+        return 0
+    fi
+    kill "$pid"
+    attempt=0
+    while kill -0 "$pid" 2>/dev/null && [ "$attempt" -lt 10 ]; do
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+    kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+    rm -f "$pidfile"
+    printf 'Crosstalk stopped\n'
+}
+
+case "${1:-start}" in
+    start) start_server ;;
+    stop) stop_server ;;
+    restart) stop_server; start_server ;;
+    status)
+        if pid=$(running_pid); then printf 'RUNNING pid=%s url=%s\n' "$pid" "$url"; else printf 'STOPPED\n'; exit 1; fi
+        ;;
+    logs) tail -n 80 "$log" ;;
+    *) printf 'Usage: crosstalk-android-server {start|stop|restart|status|logs}\n' >&2; exit 64 ;;
+esac

--- a/crosstalk.py
+++ b/crosstalk.py
@@ -26,7 +26,6 @@ except ImportError:
     webbrowser = None
 
 from peewee import SqliteDatabase
-from serial.tools import list_ports
 
 import database
 from src.backend.announce_handler import AnnounceHandler
@@ -37,6 +36,7 @@ from src.backend.interface_editor import InterfaceEditor
 from src.backend.lxmf_message_fields import LxmfImageField, LxmfFileAttachmentsField, LxmfFileAttachment, LxmfAudioField
 from src.backend.audio_call_manager import AudioCall, AudioCallManager
 from src.backend.satellite_retry_policy import SatelliteRetryPolicy
+from src.backend.serial_ports import available_serial_ports
 from src.backend.sideband_commands import SidebandCommands
 
 
@@ -486,7 +486,7 @@ class Crosstalk:
         async def index(request):
 
             comports = []
-            for comport in list_ports.comports():
+            for comport in available_serial_ports():
                 comports.append({
                     "device": comport.device,
                     "product": comport.product,

--- a/src/backend/serial_ports.py
+++ b/src/backend/serial_ports.py
@@ -1,0 +1,30 @@
+import sys
+
+
+def _load_list_ports():
+    """Load pySerial's platform-specific port enumerator when available."""
+    # pySerial emits an error to stderr before raising ImportError on Android.
+    # Avoid importing its unsupported enumerator there in the first place.
+    if sys.platform == "android":
+        return None
+
+    try:
+        from serial.tools import list_ports
+    except ImportError:
+        # pySerial intentionally raises here on unsupported platforms such as
+        # Android. Crosstalk's network interfaces still work without serial
+        # port discovery, so startup should not fail with the optional feature.
+        return None
+
+    return list_ports
+
+
+_LIST_PORTS = _load_list_ports()
+
+
+def available_serial_ports():
+    """Return detected serial ports, or an empty list when unsupported."""
+    if _LIST_PORTS is None:
+        return []
+
+    return list(_LIST_PORTS.comports())

--- a/tests/test_serial_ports.py
+++ b/tests/test_serial_ports.py
@@ -1,0 +1,41 @@
+import builtins
+import unittest
+from unittest.mock import patch
+
+from src.backend import serial_ports
+
+
+class SerialPortDiscoveryTest(unittest.TestCase):
+    def test_android_skips_unsupported_port_enumerator(self):
+        with patch.object(serial_ports.sys, "platform", "android"):
+            self.assertIsNone(serial_ports._load_list_ports())
+
+    def test_unsupported_platform_does_not_prevent_startup(self):
+        original_import = builtins.__import__
+
+        def import_without_serial_tools(name, *args, **kwargs):
+            if name == "serial.tools":
+                raise ImportError("no implementation for this platform")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=import_without_serial_tools):
+            self.assertIsNone(serial_ports._load_list_ports())
+
+    def test_unsupported_platform_returns_no_ports(self):
+        with patch.object(serial_ports, "_LIST_PORTS", None):
+            self.assertEqual(serial_ports.available_serial_ports(), [])
+
+    def test_supported_platform_returns_detected_ports(self):
+        detected_ports = [object(), object()]
+
+        class FakeListPorts:
+            @staticmethod
+            def comports():
+                return iter(detected_ports)
+
+        with patch.object(serial_ports, "_LIST_PORTS", FakeListPorts):
+            self.assertEqual(serial_ports.available_serial_ports(), detected_ports)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Fix Android/Termux startup when PySerial's native port enumerator is unavailable.
- Add a dependency-free native Android companion that renders only the local Crosstalk service.
- Add a fixed-command Termux controller for start, stop, restart, status, and logs.
- Preserve the existing Reticulum identity and application data in Termux.
- Bind the backend to `127.0.0.1:8000`; cleartext traffic is permitted only for localhost.
- Route external links to the system browser and keep WebView file access/debugging disabled.
- Add Android APK build instructions and CI coverage.

## Validation

- 31 Python tests pass.
- Frontend production build passes.
- Backend package build passes.
- Android APK builds and verifies with v2/v3 signatures.
- Tested on a rooted Samsung SM-G965F running Android 10 in portrait and landscape.
- Verified stop-to-auto-start lifecycle from the Android companion.
- Verified the Reticulum identity hash is unchanged across backend restart.

The Android shell intentionally keeps the Python/Reticulum backend in Termux. This avoids shipping a second runtime and, more importantly, preserves the user's existing identity and storage.
