### PR TITLE
Ask for microphone access on first Dictate, Add Voice, or call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ __pycache__/
 /public/
 /electron/build/exe/
 
+# Whisper weights staged at frontend build time
+src/frontend/public/assets/whisper/models/
+
 # local storage
 storage/
 *.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 # Copy required source files
 COPY *.json .
 COPY *.js .
+COPY scripts ./scripts
 COPY src/frontend ./src/frontend
 
 # Install NodeJS deps, exluding electron

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Clearer navigation, deterministic identicons and improved network-map controls.
 - Consistent in-app dialogs, notifications and status feedback.
 - Better attachment previews, attachment-only messages and mobile chat controls.
+- On-device dictation that fills the chat composer with Whisper, without sending audio off the device.
 
 ### Reliability improvements and bug fixes
 
@@ -80,6 +81,8 @@ python3 crosstalk.py
 ```
 
 Open <http://localhost:8000>. Run `python3 crosstalk.py --help` for server, identity, storage and Reticulum configuration options.
+
+`npm run build-frontend` also downloads Whisper Tiny so chat dictation can run entirely on-device. See [dictation.md](./docs/dictation.md).
 
 ## Development
 

--- a/docs/crosstalk_on_raspberry_pi.md
+++ b/docs/crosstalk_on_raspberry_pi.md
@@ -46,6 +46,9 @@ npm install --omit=dev
 npm run build-frontend
 ```
 
+The frontend build downloads Whisper Tiny weights for on-device chat dictation.
+That step needs internet once; speaking into the composer does not.
+
 ## Run Crosstalk
 
 ```

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -18,8 +18,8 @@ The first use in a session loads the local Whisper model into memory, which can
 take a few seconds. Later dictations reuse that in-memory model.
 
 Dictation uses the same microphone permission as audio calls and voice
-messages. On macOS the app prompts for microphone access at launch. Windows and
-Linux prompt when the microphone is first used.
+messages. The app asks for access the first time you use Dictate, Add Voice,
+or start a call. Windows and Linux also prompt on first capture.
 
 ## Privacy
 

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -1,0 +1,55 @@
+# On-device chat dictation
+
+Crosstalk can fill the chat composer from the microphone using Whisper Tiny.
+Speech is transcribed in the local UI process. Audio is not sent to a cloud
+speech API, Hugging Face, or any other remote service.
+
+This is separate from **Add Voice**, which attaches Codec2 or Opus audio to an
+LXMF message.
+
+## Using dictation
+
+1. Open a conversation.
+2. Click **Dictate**.
+3. Speak, then click the red **Listening** button to stop.
+4. Review the text in the composer and send it as a normal message.
+
+The first use in a session loads the local Whisper model into memory, which can
+take a few seconds. Later dictations reuse that in-memory model.
+
+Dictation uses the same microphone permission as audio calls and voice
+messages. On macOS the app prompts for microphone access at launch. Windows and
+Linux prompt when the microphone is first used.
+
+## Privacy
+
+- Microphone samples stay in RAM on the local machine.
+- Transcription runs in a Web Worker with Whisper Tiny (`q8`) and ONNX Runtime
+  WASM.
+- `env.allowRemoteModels` is disabled, so the worker will not fetch weights
+  from the Hugging Face Hub at runtime.
+- The OS/browser language is passed to Whisper as a hint. That value never
+  leaves the device.
+
+## Build-time assets
+
+`npm run build-frontend` runs `scripts/download-whisper-assets.mjs`, which
+downloads quantized Whisper Tiny files from Hugging Face into
+`src/frontend/public/assets/whisper/models/`. Vite then bundles ONNX Runtime
+WASM from the local `onnxruntime-web` install.
+
+Those files are served by Crosstalk's own HTTP server (including packaged
+Electron builds). A network connection is only required while *building*, not
+while dictating.
+
+After a fresh clone, run `npm install` and `npm run build-frontend` before
+using dictation.
+
+## Limits
+
+- Recordings stop automatically after 60 seconds.
+- Very short or silent captures are ignored.
+- Whisper Tiny is a small model. Accents, noise and uncommon words may need a
+  quick edit before sending.
+- A Raspberry Pi can run this path, but the first load and each transcription
+  will be slower than on a desktop CPU.

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -24,8 +24,9 @@ Linux prompt when the microphone is first used.
 ## Privacy
 
 - Microphone samples stay in RAM on the local machine.
-- Transcription runs in a Web Worker with Whisper Tiny (`q8`) and ONNX Runtime
-  WASM.
+- Transcription runs in a Web Worker with Whisper Tiny (`fp32`) and ONNX Runtime
+  WASM. Quantized (`q8`) Whisper graphs are avoided because the current
+  Transformers.js / ONNX Runtime combination rejects them.
 - `env.allowRemoteModels` is disabled, so the worker will not fetch weights
   from the Hugging Face Hub at runtime.
 - The OS/browser language is passed to Whisper as a hint. That value never
@@ -34,7 +35,7 @@ Linux prompt when the microphone is first used.
 ## Build-time assets
 
 `npm run build-frontend` runs `scripts/download-whisper-assets.mjs`, which
-downloads quantized Whisper Tiny files from Hugging Face into
+downloads Whisper Tiny fp32 ONNX files from Hugging Face into
 `src/frontend/public/assets/whisper/models/`. Vite then bundles ONNX Runtime
 WASM from the local `onnxruntime-web` install.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,6 +13,9 @@ git tag -a v2.3.2 -m "Crosstalk v2.3.2"
 git push origin v2.3.2
 ```
 
+Frontend builds download quantized Whisper Tiny weights so packaged apps can
+dictate chat messages entirely on-device. See [dictation.md](./dictation.md).
+
 The release workflow produces:
 
 - a Windows x64 installer

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,7 +13,7 @@ git tag -a v2.3.2 -m "Crosstalk v2.3.2"
 git push origin v2.3.2
 ```
 
-Frontend builds download quantized Whisper Tiny weights so packaged apps can
+Frontend builds download Whisper Tiny fp32 weights so packaged apps can
 dictate chat messages entirely on-device. See [dictation.md](./dictation.md).
 
 The release workflow produces:

--- a/electron/main.js
+++ b/electron/main.js
@@ -273,7 +273,7 @@ app.whenReady().then(async () => {
         // navigate to loading page
         await mainWindow.loadFile(path.join(__dirname, 'loading.html'));
 
-        // ask mac users for microphone access for audio calls to work
+        // ask mac users for microphone access for audio calls, voice messages and on-device dictation
         if(process.platform === "darwin"){
             await systemPreferences.askForMediaAccess('microphone');
         }

--- a/electron/main.js
+++ b/electron/main.js
@@ -69,6 +69,15 @@ ipcMain.handle('showPathInFolder', (event, path) => {
     shell.showItemInFolder(path);
 });
 
+// Prompt for microphone access the first time capture is requested.
+// macOS needs this TCC dialog; other platforms return true immediately.
+ipcMain.handle('ask-for-microphone-access', async() => {
+    if(process.platform !== "darwin"){
+        return true;
+    }
+    return await systemPreferences.askForMediaAccess('microphone');
+});
+
 function log(message) {
 
     // log to stdout of this process
@@ -272,11 +281,6 @@ app.whenReady().then(async () => {
 
         // navigate to loading page
         await mainWindow.loadFile(path.join(__dirname, 'loading.html'));
-
-        // ask mac users for microphone access for audio calls, voice messages and on-device dictation
-        if(process.platform === "darwin"){
-            await systemPreferences.askForMediaAccess('microphone');
-        }
 
     }
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -40,4 +40,9 @@ contextBridge.exposeInMainWorld('electron', {
         return await ipcRenderer.invoke('showPathInFolder', path);
     },
 
+    // ask for microphone access on first capture (macOS TCC)
+    askForMicrophoneAccess: async function() {
+        return await ipcRenderer.invoke('ask-for-microphone-access');
+    },
+
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "@mdi/js": "^7.4.47",
         "@tailwindcss/forms": "^0.5.9",
         "@vitejs/plugin-vue": "^5.2.1",
@@ -545,6 +546,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -959,6 +970,547 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1963,6 +2515,15 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2403,9 +2964,7 @@
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
     },
     "node_modules/brace-expansion": {
       "version": "2.1.4",
@@ -2937,8 +3496,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2955,8 +3512,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -2977,12 +3532,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3444,9 +4006,7 @@
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3501,8 +4061,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -3614,6 +4172,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -3828,8 +4392,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -3846,8 +4408,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -3902,6 +4462,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3916,8 +4482,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -4226,9 +4790,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4338,8 +4900,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -4714,8 +5274,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4728,6 +5286,49 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -4880,6 +5481,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -5372,8 +5979,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -5484,7 +6089,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5496,16 +6100,12 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -5514,6 +6114,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -5590,9 +6234,7 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
@@ -6035,34 +6677,18 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "electron/main.js",
   "scripts": {
     "watch": "npm run build-frontend -- --watch",
-    "build-frontend": "vite build",
+    "download-whisper-assets": "node scripts/download-whisper-assets.mjs",
+    "build-frontend": "npm run download-whisper-assets && vite build",
     "build-backend": "python setup.py build",
     "build": "npm run build-frontend && npm run build-backend",
     "electron-postinstall": "electron-builder install-app-deps",
@@ -38,7 +39,7 @@
       "hardenedRuntime": false,
       "artifactName": "Crosstalk-v${version}-macos-${arch}.${ext}",
       "extendInfo": {
-        "NSMicrophoneUsageDescription": "Microphone access is only needed for Audio Calls",
+        "NSMicrophoneUsageDescription": "Crosstalk uses the microphone for audio calls, voice messages and on-device dictation.",
         "com.apple.security.device.audio-input": true
       },
       "extraFiles": [
@@ -97,6 +98,7 @@
     }
   },
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@mdi/js": "^7.4.47",
     "@tailwindcss/forms": "^0.5.9",
     "@vitejs/plugin-vue": "^5.2.1",

--- a/scripts/download-whisper-assets.mjs
+++ b/scripts/download-whisper-assets.mjs
@@ -25,8 +25,11 @@ const MODEL_REVISION = "main";
 const USER_AGENT = "crosstalk-whisper-asset-download";
 
 /**
- * Small tokenizer/config files plus the quantized encoder/decoder used with dtype q8.
- * Larger fp16/fp32 ONNX variants are intentionally omitted to keep the app size down.
+ * Tokenizer/config files plus the fp32 encoder/decoder used with dtype fp32.
+ *
+ * Quantized (`*_quantized.onnx`) Whisper graphs currently fail under
+ * @huggingface/transformers 4.2 + onnxruntime-web with MatMulNBits missing-scale
+ * errors, so we stage the fp32 weights instead.
  */
 const MODEL_FILES = [
     "added_tokens.json",
@@ -35,11 +38,17 @@ const MODEL_FILES = [
     "merges.txt",
     "normalizer.json",
     "preprocessor_config.json",
-    "quant_config.json",
     "special_tokens_map.json",
     "tokenizer.json",
     "tokenizer_config.json",
     "vocab.json",
+    "onnx/encoder_model.onnx",
+    "onnx/decoder_model_merged.onnx",
+];
+
+/** Older q8 assets left behind from earlier builds; safe to drop. */
+const OBSOLETE_MODEL_FILES = [
+    "quant_config.json",
     "onnx/encoder_model_quantized.onnx",
     "onnx/decoder_model_merged_quantized.onnx",
 ];
@@ -90,10 +99,22 @@ async function ensureModelFiles() {
     }
 }
 
+async function removeObsoleteModelFiles() {
+    for (const relativePath of OBSOLETE_MODEL_FILES) {
+        const destinationPath = path.join(modelDir, relativePath);
+        if (!fs.existsSync(destinationPath)) {
+            continue;
+        }
+        await fs.promises.unlink(destinationPath);
+        console.log(`removed obsolete whisper asset: ${relativePath}`);
+    }
+}
+
 async function main() {
     console.log("Preparing on-device Whisper assets…");
     await fs.promises.mkdir(assetsRoot, { recursive: true });
     await ensureModelFiles();
+    await removeObsoleteModelFiles();
     console.log("Whisper assets are ready.");
 }
 

--- a/scripts/download-whisper-assets.mjs
+++ b/scripts/download-whisper-assets.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Download and stage the on-device Whisper assets used by chat dictation.
+ *
+ * This keeps speech-to-text fully local at runtime:
+ * - Whisper Tiny weights are fetched from Hugging Face at *build* time.
+ * - ONNX Runtime WASM is bundled by Vite from the local onnxruntime-web install.
+ * - The packaged app then loads both from its own static file server.
+ *
+ * Audio recorded in the UI is never uploaded anywhere.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const assetsRoot = path.join(repoRoot, "src", "frontend", "public", "assets", "whisper");
+const modelDir = path.join(assetsRoot, "models", "Xenova", "whisper-tiny");
+
+const MODEL_HOST = "https://huggingface.co";
+const MODEL_ID = "Xenova/whisper-tiny";
+const MODEL_REVISION = "main";
+const USER_AGENT = "crosstalk-whisper-asset-download";
+
+/**
+ * Small tokenizer/config files plus the quantized encoder/decoder used with dtype q8.
+ * Larger fp16/fp32 ONNX variants are intentionally omitted to keep the app size down.
+ */
+const MODEL_FILES = [
+    "added_tokens.json",
+    "config.json",
+    "generation_config.json",
+    "merges.txt",
+    "normalizer.json",
+    "preprocessor_config.json",
+    "quant_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+    "onnx/encoder_model_quantized.onnx",
+    "onnx/decoder_model_merged_quantized.onnx",
+];
+
+function modelFileUrl(relativePath) {
+    return `${MODEL_HOST}/${MODEL_ID}/resolve/${MODEL_REVISION}/${relativePath}`;
+}
+
+async function downloadFile(url, destinationPath) {
+    await fs.promises.mkdir(path.dirname(destinationPath), { recursive: true });
+
+    const response = await fetch(url, {
+        headers: {
+            "User-Agent": USER_AGENT,
+        },
+        redirect: "follow",
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to download ${url} (${response.status} ${response.statusText})`);
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    await fs.promises.writeFile(destinationPath, bytes);
+    return bytes.length;
+}
+
+function fileLooksComplete(filePath) {
+    try {
+        return fs.statSync(filePath).size > 0;
+    } catch (_error) {
+        return false;
+    }
+}
+
+async function ensureModelFiles() {
+    for (const relativePath of MODEL_FILES) {
+        const destinationPath = path.join(modelDir, relativePath);
+        if (fileLooksComplete(destinationPath)) {
+            console.log(`whisper model already present: ${relativePath}`);
+            continue;
+        }
+
+        const url = modelFileUrl(relativePath);
+        console.log(`downloading whisper model file: ${relativePath}`);
+        const size = await downloadFile(url, destinationPath);
+        console.log(`  saved ${size} bytes`);
+    }
+}
+
+async function main() {
+    console.log("Preparing on-device Whisper assets…");
+    await fs.promises.mkdir(assetsRoot, { recursive: true });
+    await ensureModelFiles();
+    console.log("Whisper assets are ready.");
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/frontend/components/call/CallPage.vue
+++ b/src/frontend/components/call/CallPage.vue
@@ -280,6 +280,7 @@
 <script>
 import protobuf from "protobufjs";
 import DialogUtils from "../../js/DialogUtils";
+import ElectronUtils from "../../js/ElectronUtils";
 import CopyButton from "../CopyButton.vue";
 import ModalHost from "../overlays/ModalHost.vue";
 import ToastHost from "../overlays/ToastHost.vue";
@@ -567,6 +568,11 @@ export default {
         },
         async startRecordingMicrophone(onAudioAvailable) {
             try {
+
+                if(!await ElectronUtils.ensureMicrophoneAccess()){
+                    DialogUtils.toast("Microphone access is required for audio calls.", "error");
+                    return;
+                }
 
                 // load audio worklet module
                 this.audioContext = new AudioContext({ sampleRate: this.sampleRate });

--- a/src/frontend/components/messages/ConversationViewer.vue
+++ b/src/frontend/components/messages/ConversationViewer.vue
@@ -457,6 +457,7 @@ import ConversationDropDownMenu from "./ConversationDropDownMenu.vue";
 import AddImageButton from "./AddImageButton.vue";
 import IconButton from "../IconButton.vue";
 import GlobalEmitter from "../../js/GlobalEmitter";
+import ElectronUtils from "../../js/ElectronUtils";
 import CopyButton from "../CopyButton.vue";
 import LxmfUserIcon from "../LxmfUserIcon.vue";
 import EmptyState from "../base/EmptyState.vue";
@@ -1368,6 +1369,11 @@ export default {
                 return;
             }
 
+            if(!await ElectronUtils.ensureMicrophoneAccess()){
+                DialogUtils.alert("Microphone access is required to record a voice message.");
+                return;
+            }
+
             // handle selected codec
             switch(args.codec){
                 case "codec2": {
@@ -1610,6 +1616,11 @@ export default {
             }
             if(this.isRecordingAudioAttachment){
                 DialogUtils.alert("Stop the voice recording before dictating a message.");
+                return;
+            }
+
+            if(!await ElectronUtils.ensureMicrophoneAccess()){
+                DialogUtils.alert("Microphone access is required for dictation.");
                 return;
             }
 

--- a/src/frontend/components/messages/ConversationViewer.vue
+++ b/src/frontend/components/messages/ConversationViewer.vue
@@ -358,13 +358,13 @@
                     <textarea
                         ref="message-input"
                         id="message-input"
-                        :readonly="isSendingMessage"
+                        :readonly="isSendingMessage || isDictationBusy"
                         v-model="newMessageText"
                         @keydown.enter.exact.native.prevent="onEnterPressed"
                         @keydown.enter.shift.exact.native.prevent="onShiftEnterPressed"
                         class="ct-message-input block w-full resize-none rounded-xl border p-2.5 text-base sm:text-sm"
                         rows="2"
-                        placeholder="Send a message…"></textarea>
+                        :placeholder="messageInputPlaceholder"></textarea>
 
                     <!-- action button -->
                     <div class="flex items-center mt-2">
@@ -391,6 +391,14 @@
                                 @stop-recording="stopRecordingAudioAttachment">
                                 <span>Recording: {{ audioAttachmentRecordingDuration }}</span>
                             </AddAudioButton>
+                        </div>
+
+                        <!-- dictate into the text field using on-device Whisper -->
+                        <div>
+                            <DictateButton
+                                :state="dictationState"
+                                :duration="dictationDuration"
+                                @toggle="toggleDictation"/>
                         </div>
 
                         <!-- send message -->
@@ -440,8 +448,10 @@ import MicrophoneRecorder from "../../js/MicrophoneRecorder";
 import NotificationUtils from "../../js/NotificationUtils";
 import WebSocketConnection from "../../js/WebSocketConnection";
 import AddAudioButton from "./AddAudioButton.vue";
+import DictateButton from "./DictateButton.vue";
 import moment from "moment";
 import SendMessageButton from "./SendMessageButton.vue";
+import WhisperSpeechToText, { MAX_RECORDING_SECONDS } from "../../js/WhisperSpeechToText";
 import MaterialDesignIcon from "../MaterialDesignIcon.vue";
 import ConversationDropDownMenu from "./ConversationDropDownMenu.vue";
 import AddImageButton from "./AddImageButton.vue";
@@ -461,6 +471,7 @@ export default {
         MaterialDesignIcon,
         SendMessageButton,
         AddAudioButton,
+        DictateButton,
         LxmfUserIcon,
         EmptyState,
     },
@@ -496,6 +507,12 @@ export default {
             isSendingMessage: false,
             autoScrollOnNewMessage: true,
 
+            dictationState: "idle",
+            dictationDuration: "00:00",
+            dictationTimer: null,
+            dictationMaxTimer: null,
+            dictationSession: 0,
+
             isRecordingAudioAttachment: false,
             audioAttachmentMicrophoneRecorder: null,
             audioAttachmentMicrophoneRecorderCodec: null,
@@ -524,6 +541,11 @@ export default {
 
         // stop polling satellite signal
         clearInterval(this.satelliteSignalTimer);
+
+        // drop the mic if this conversation is leaving the page
+        this.dictationSession += 1;
+        this.stopDictationTimers();
+        WhisperSpeechToText.getShared().cancelRecording();
 
     },
     mounted() {
@@ -1335,6 +1357,12 @@ export default {
                 return;
             }
 
+            // the microphone can only be used by one feature at a time
+            if(this.dictationState !== "idle"){
+                DialogUtils.alert("Stop dictation before recording a voice message.");
+                return;
+            }
+
             // ask user to confirm recording new audio attachment, if an existing audio attachment exists
             if(this.newMessageAudio && !await DialogUtils.confirm("An audio recording is already attached. A new recording will replace it. Do you want to continue?")){
                 return;
@@ -1514,6 +1542,11 @@ export default {
         },
         onEnterPressed: function() {
 
+            // don't send while the composer is capturing or transcribing speech
+            if(this.dictationState !== "idle"){
+                return;
+            }
+
             // add new line on mobile
             if(this.isMobile){
                 this.addNewLine();
@@ -1523,6 +1556,128 @@ export default {
             // send message on desktop
             this.sendMessage();
 
+        },
+        /**
+         * Insert on-device Whisper text at the caret in the chat composer.
+         * @param {string} text
+         */
+        insertDictationText(text) {
+            const transcript = (text || "").trim();
+            if(!transcript){
+                return;
+            }
+
+            const input = this.$refs["message-input"];
+            const start = input?.selectionStart ?? this.newMessageText.length;
+            const end = input?.selectionEnd ?? this.newMessageText.length;
+            const value = this.newMessageText;
+            const needsSpace = start > 0 && !/\s$/.test(value.slice(0, start));
+            const prefix = needsSpace ? " " : "";
+            this.newMessageText = value.slice(0, start) + prefix + transcript + value.slice(end);
+
+            this.$nextTick(() => {
+                if(!input){
+                    return;
+                }
+                const pos = start + prefix.length + transcript.length;
+                input.selectionStart = pos;
+                input.selectionEnd = pos;
+                input.focus();
+            });
+        },
+        stopDictationTimers() {
+            clearInterval(this.dictationTimer);
+            clearTimeout(this.dictationMaxTimer);
+            this.dictationTimer = null;
+            this.dictationMaxTimer = null;
+        },
+        /**
+         * Toggle push-to-talk dictation. Transcription is local Whisper Tiny.
+         */
+        async toggleDictation() {
+            if(this.dictationState === "recording"){
+                await this.stopDictationAndTranscribe();
+                return;
+            }
+            if(this.dictationState !== "idle"){
+                return;
+            }
+            await this.startDictation();
+        },
+        async startDictation() {
+            if(this.isSendingMessage){
+                return;
+            }
+            if(this.isRecordingAudioAttachment){
+                DialogUtils.alert("Stop the voice recording before dictating a message.");
+                return;
+            }
+
+            const speech = WhisperSpeechToText.getShared();
+            const session = this.dictationSession + 1;
+            this.dictationSession = session;
+            this.dictationDuration = Utils.formatMinutesSeconds(0);
+
+            try {
+                // Load Whisper while capturing so the first use can start speaking immediately.
+                speech.ensureReady().catch((error) => {
+                    console.log(error);
+                });
+
+                const started = await speech.startRecording();
+                if(session !== this.dictationSession){
+                    speech.cancelRecording();
+                    return;
+                }
+                if(!started){
+                    this.dictationState = "idle";
+                    DialogUtils.alert("Could not access the microphone for dictation.");
+                    return;
+                }
+
+                this.dictationState = "recording";
+                this.dictationTimer = setInterval(() => {
+                    this.dictationDuration = Utils.formatMinutesSeconds(speech.getElapsedSeconds());
+                }, 250);
+                this.dictationMaxTimer = setTimeout(() => {
+                    this.stopDictationAndTranscribe();
+                }, MAX_RECORDING_SECONDS * 1000);
+            } catch(error) {
+                speech.cancelRecording();
+                this.dictationState = "idle";
+                DialogUtils.alert(error?.message || "Failed to start on-device dictation.");
+            }
+        },
+        async stopDictationAndTranscribe() {
+            if(this.dictationState !== "recording"){
+                return;
+            }
+
+            const session = this.dictationSession;
+            this.stopDictationTimers();
+            this.dictationState = "transcribing";
+
+            try {
+                const text = await WhisperSpeechToText.getShared().stopRecordingAndTranscribe();
+                if(session !== this.dictationSession){
+                    return;
+                }
+                if(!text){
+                    DialogUtils.toast("No speech detected", "info");
+                } else {
+                    this.insertDictationText(text);
+                }
+            } catch(error) {
+                if(session !== this.dictationSession){
+                    return;
+                }
+                DialogUtils.alert(error?.message || "Failed to transcribe speech on this device.");
+            } finally {
+                if(session === this.dictationSession){
+                    this.dictationState = "idle";
+                    this.dictationDuration = "00:00";
+                }
+            }
         },
         onShiftEnterPressed: function() {
             this.addNewLine();
@@ -1750,6 +1905,21 @@ export default {
         isMobile() {
             return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
         },
+        isDictationBusy() {
+            return this.dictationState === "loading" || this.dictationState === "transcribing";
+        },
+        messageInputPlaceholder() {
+            if(this.dictationState === "loading"){
+                return "Loading on-device speech model…";
+            }
+            if(this.dictationState === "recording"){
+                return "Listening…";
+            }
+            if(this.dictationState === "transcribing"){
+                return "Transcribing on this device…";
+            }
+            return "Send a message…";
+        },
         canSendMessage() {
 
             // can't send if no content or attachments
@@ -1761,6 +1931,11 @@ export default {
 
             // can't send if already sending
             if(this.isSendingMessage){
+                return false;
+            }
+
+            // wait until dictation has finished inserting text
+            if(this.dictationState !== "idle"){
                 return false;
             }
 
@@ -1805,6 +1980,11 @@ export default {
     },
     watch: {
         selectedPeer() {
+            this.dictationSession += 1;
+            this.stopDictationTimers();
+            WhisperSpeechToText.getShared().cancelRecording();
+            this.dictationState = "idle";
+            this.dictationDuration = "00:00";
             this.initialLoad();
         },
         async selectedPeerChatItems() {

--- a/src/frontend/components/messages/DictateButton.vue
+++ b/src/frontend/components/messages/DictateButton.vue
@@ -1,0 +1,94 @@
+<template>
+    <div class="inline-flex rounded-md shadow-sm">
+
+        <button
+            v-if="isActive"
+            @click="toggle"
+            type="button"
+            :aria-label="ariaLabel"
+            class="my-auto mr-1 inline-flex min-h-11 items-center gap-x-1 rounded-lg bg-red-500 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 sm:min-h-0 sm:rounded-md">
+            <MaterialDesignIcon icon-name="microphone-message" class="size-5"/>
+            <span class="ml-1">{{ activeLabel }}</span>
+        </button>
+
+        <button
+            v-else
+            @click="toggle"
+            type="button"
+            :disabled="isBusy"
+            :aria-label="ariaLabel"
+            class="my-auto mr-1 inline-flex min-h-11 min-w-11 items-center justify-center gap-x-1 rounded-lg ct-secondary-button px-2.5 py-1.5 text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 sm:min-h-0 sm:min-w-0 sm:rounded-md disabled:opacity-50">
+            <MaterialDesignIcon icon-name="microphone-message" class="size-5"/>
+            <span class="ml-1 hidden xl:inline-block whitespace-nowrap">{{ idleLabel }}</span>
+        </button>
+
+    </div>
+</template>
+
+<script>
+import MaterialDesignIcon from "../MaterialDesignIcon.vue";
+
+/**
+ * Composer control that records speech and fills the chat text field.
+ * Distinct from Add Voice, which attaches encoded audio to the LXMF message.
+ */
+export default {
+    name: "DictateButton",
+    components: {
+        MaterialDesignIcon,
+    },
+    props: {
+        /**
+         * idle | loading | recording | transcribing
+         */
+        state: {
+            type: String,
+            default: "idle",
+        },
+        duration: {
+            type: String,
+            default: "00:00",
+        },
+    },
+    computed: {
+        isActive() {
+            return this.state === "recording";
+        },
+        isBusy() {
+            return this.state === "loading" || this.state === "transcribing";
+        },
+        idleLabel() {
+            if (this.state === "loading") {
+                return "Loading…";
+            }
+            if (this.state === "transcribing") {
+                return "Transcribing…";
+            }
+            return "Dictate";
+        },
+        activeLabel() {
+            return `Listening: ${this.duration}`;
+        },
+        ariaLabel() {
+            if (this.state === "recording") {
+                return "Stop dictation";
+            }
+            if (this.state === "loading") {
+                return "Loading on-device speech model";
+            }
+            if (this.state === "transcribing") {
+                return "Transcribing speech";
+            }
+            return "Dictate message";
+        },
+    },
+    methods: {
+        toggle() {
+            if (this.isBusy) {
+                return;
+            }
+            this.$emit("toggle");
+        },
+    },
+}
+</script>

--- a/src/frontend/js/ElectronUtils.js
+++ b/src/frontend/js/ElectronUtils.js
@@ -51,6 +51,18 @@ class ElectronUtils {
         }
     }
 
+    /**
+     * Ask for microphone access before first capture.
+     * In Electron on macOS this shows the TCC prompt. In the browser it is a
+     * no-op; getUserMedia will prompt instead. Returns false if denied.
+     */
+    static async ensureMicrophoneAccess() {
+        if(window.electron?.askForMicrophoneAccess){
+            return await window.electron.askForMicrophoneAccess();
+        }
+        return true;
+    }
+
 }
 
 export default ElectronUtils;

--- a/src/frontend/js/PcmMicrophoneRecorder.js
+++ b/src/frontend/js/PcmMicrophoneRecorder.js
@@ -1,0 +1,175 @@
+import processorUrl from "./whisper-pcm-processor.js?url";
+
+const WHISPER_SAMPLE_RATE = 16000;
+
+/**
+ * Records microphone audio as 16 kHz mono PCM for on-device Whisper.
+ *
+ * Audio is kept in memory only. Tracks are stopped when recording ends so the
+ * OS microphone indicator is released promptly.
+ */
+class PcmMicrophoneRecorder {
+
+    constructor() {
+        this.audioContext = null;
+        this.mediaStream = null;
+        this.mediaStreamSource = null;
+        this.workletNode = null;
+        this.chunks = [];
+        this.startedAt = null;
+    }
+
+    /**
+     * Begin capturing microphone samples.
+     * @returns {Promise<boolean>} true when the mic is live
+     */
+    async start() {
+        try {
+            this.chunks = [];
+            this.mediaStream = await navigator.mediaDevices.getUserMedia({
+                audio: {
+                    channelCount: 1,
+                    echoCancellation: true,
+                    noiseSuppression: true,
+                    autoGainControl: true,
+                },
+            });
+
+            this.audioContext = new AudioContext();
+            await this.audioContext.audioWorklet.addModule(processorUrl);
+            this.workletNode = new AudioWorkletNode(this.audioContext, "whisper-pcm-processor");
+            this.workletNode.port.onmessage = (event) => {
+                this.chunks.push(event.data);
+            };
+
+            this.mediaStreamSource = this.audioContext.createMediaStreamSource(this.mediaStream);
+            this.mediaStreamSource.connect(this.workletNode);
+            this.startedAt = Date.now();
+            return true;
+        } catch (_error) {
+            this.stopTracks();
+            return false;
+        }
+    }
+
+    /**
+     * Stop capture and return 16 kHz mono samples for Whisper.
+     * @returns {Promise<Float32Array>}
+     */
+    async stop() {
+        const nativeRate = this.audioContext?.sampleRate || WHISPER_SAMPLE_RATE;
+        const samples = this.concatenateChunks();
+        this.cleanup();
+        return downsampleToRate(samples, nativeRate, WHISPER_SAMPLE_RATE);
+    }
+
+    /**
+     * Stop capture and discard samples, for example when the conversation closes.
+     */
+    cancel() {
+        this.cleanup();
+    }
+
+    /**
+     * Seconds captured so far, or 0 if recording has not started.
+     * @returns {number}
+     */
+    getElapsedSeconds() {
+        if (this.startedAt == null) {
+            return 0;
+        }
+        return (Date.now() - this.startedAt) / 1000;
+    }
+
+    concatenateChunks() {
+        let length = 0;
+        for (const chunk of this.chunks) {
+            length += chunk.length;
+        }
+        const samples = new Float32Array(length);
+        let offset = 0;
+        for (const chunk of this.chunks) {
+            samples.set(chunk, offset);
+            offset += chunk.length;
+        }
+        return samples;
+    }
+
+    stopTracks() {
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach((track) => track.stop());
+        }
+    }
+
+    cleanup() {
+        this.stopTracks();
+        if (this.mediaStreamSource) {
+            this.mediaStreamSource.disconnect();
+        }
+        if (this.workletNode) {
+            this.workletNode.disconnect();
+        }
+        if (this.audioContext && this.audioContext.state !== "closed") {
+            this.audioContext.close();
+        }
+        this.audioContext = null;
+        this.mediaStream = null;
+        this.mediaStreamSource = null;
+        this.workletNode = null;
+        this.chunks = [];
+        this.startedAt = null;
+    }
+}
+
+/**
+ * Average-pool PCM to Whisper's expected 16 kHz rate.
+ * @param {Float32Array} samples
+ * @param {number} inputRate
+ * @param {number} outputRate
+ * @returns {Float32Array}
+ */
+export function downsampleToRate(samples, inputRate, outputRate) {
+    if (!samples || samples.length === 0) {
+        return new Float32Array(0);
+    }
+    if (inputRate === outputRate) {
+        return samples;
+    }
+
+    const ratio = inputRate / outputRate;
+    const outputLength = Math.max(1, Math.round(samples.length / ratio));
+    const output = new Float32Array(outputLength);
+    let offsetResult = 0;
+    let offsetBuffer = 0;
+    while (offsetResult < output.length) {
+        const nextOffsetBuffer = Math.round((offsetResult + 1) * ratio);
+        let accum = 0;
+        let count = 0;
+        for (let i = offsetBuffer; i < nextOffsetBuffer && i < samples.length; i++) {
+            accum += samples[i];
+            count++;
+        }
+        output[offsetResult] = count > 0 ? accum / count : 0;
+        offsetResult++;
+        offsetBuffer = nextOffsetBuffer;
+    }
+    return output;
+}
+
+/**
+ * Mean-square energy used to ignore near-silent recordings.
+ * @param {Float32Array} samples
+ * @returns {number}
+ */
+export function rootMeanSquare(samples) {
+    if (!samples || samples.length === 0) {
+        return 0;
+    }
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) {
+        sum += samples[i] * samples[i];
+    }
+    return Math.sqrt(sum / samples.length);
+}
+
+export default PcmMicrophoneRecorder;

--- a/src/frontend/js/WhisperSpeechToText.js
+++ b/src/frontend/js/WhisperSpeechToText.js
@@ -1,0 +1,236 @@
+import PcmMicrophoneRecorder, { rootMeanSquare } from "./PcmMicrophoneRecorder";
+import WhisperWorker from "./whisper.worker.js?worker";
+
+const MAX_RECORDING_SECONDS = 60;
+const MIN_RECORDING_SECONDS = 0.35;
+const SILENCE_RMS_THRESHOLD = 0.008;
+
+let sharedInstance = null;
+
+/**
+ * On-device speech-to-text for the chat composer.
+ *
+ * Recording stays in this process. Transcription runs in a Web Worker with
+ * Whisper Tiny (WASM). The worker is reused so the model is only loaded once
+ * per app session.
+ */
+class WhisperSpeechToText {
+
+    constructor() {
+        this.worker = null;
+        this.workerReady = false;
+        this.readyPromise = null;
+        this.recorder = null;
+        this.pending = new Map();
+        this.nextRequestId = 1;
+        this.loadWaiters = [];
+    }
+
+    /**
+     * Shared engine so switching conversations does not reload the 40 MB model.
+     * @returns {WhisperSpeechToText}
+     */
+    static getShared() {
+        if (!sharedInstance) {
+            sharedInstance = new WhisperSpeechToText();
+        }
+        return sharedInstance;
+    }
+
+    /**
+     * BCP-47 language from the OS/browser, mapped to a Whisper language code.
+     * Short clips transcribe more reliably when the language is known.
+     * @returns {string|null}
+     */
+    static detectLanguage() {
+        const locale = (navigator.language || "").trim();
+        if (!locale) {
+            return null;
+        }
+        return locale.split("-")[0].toLowerCase() || null;
+    }
+
+    ensureWorker() {
+        if (this.worker) {
+            return;
+        }
+
+        this.worker = new WhisperWorker();
+        this.worker.onmessage = (event) => {
+            const { type, requestId, text, message, progress } = event.data || {};
+
+            if (type === "progress") {
+                for (const waiter of this.loadWaiters) {
+                    waiter.onProgress?.(progress);
+                }
+                return;
+            }
+
+            if (type === "ready") {
+                this.workerReady = true;
+                this.resolvePending(requestId, true);
+                return;
+            }
+
+            if (type === "result") {
+                this.resolvePending(requestId, text || "");
+                return;
+            }
+
+            if (type === "error") {
+                this.rejectPending(requestId, new Error(message || "Whisper failed"));
+            }
+        };
+
+        this.worker.onerror = (error) => {
+            const failure = new Error(error?.message || "Whisper worker failed");
+            for (const [requestId] of this.pending) {
+                this.rejectPending(requestId, failure);
+            }
+        };
+    }
+
+    /**
+     * Load Whisper Tiny into the worker. Safe to call more than once.
+     * @param {(progress: object) => void} [onProgress]
+     * @returns {Promise<void>}
+     */
+    async ensureReady(onProgress) {
+        this.ensureWorker();
+        if (this.workerReady) {
+            return;
+        }
+
+        if (!this.readyPromise) {
+            const requestId = this.nextRequestId++;
+            this.readyPromise = this.waitForWorker(requestId).catch((error) => {
+                this.readyPromise = null;
+                throw error;
+            });
+            this.worker.postMessage({ type: "load", requestId });
+        }
+
+        if (onProgress) {
+            this.loadWaiters.push({ onProgress });
+        }
+
+        try {
+            await this.readyPromise;
+        } finally {
+            this.loadWaiters = this.loadWaiters.filter((waiter) => waiter.onProgress !== onProgress);
+        }
+    }
+
+    /**
+     * Start capturing microphone PCM.
+     * @returns {Promise<boolean>}
+     */
+    async startRecording() {
+        if (this.recorder) {
+            return true;
+        }
+        this.recorder = new PcmMicrophoneRecorder();
+        const started = await this.recorder.start();
+        if (!started) {
+            this.recorder = null;
+        }
+        return started;
+    }
+
+    /**
+     * Whether the microphone is currently capturing dictation audio.
+     * @returns {boolean}
+     */
+    isRecording() {
+        return this.recorder != null;
+    }
+
+    /**
+     * Seconds captured in the current dictation take.
+     * @returns {number}
+     */
+    getElapsedSeconds() {
+        return this.recorder ? this.recorder.getElapsedSeconds() : 0;
+    }
+
+    /**
+     * Stop the mic without transcribing, for example when leaving a chat.
+     */
+    cancelRecording() {
+        if (this.recorder) {
+            this.recorder.cancel();
+            this.recorder = null;
+        }
+    }
+
+    /**
+     * Stop the microphone and transcribe the captured audio on-device.
+     * @returns {Promise<string>}
+     */
+    async stopRecordingAndTranscribe() {
+        if (!this.recorder) {
+            return "";
+        }
+
+        const elapsed = this.recorder.getElapsedSeconds();
+        const samples = await this.recorder.stop();
+        this.recorder = null;
+
+        if (elapsed < MIN_RECORDING_SECONDS || samples.length < WHISPER_MIN_SAMPLES) {
+            return "";
+        }
+        if (rootMeanSquare(samples) < SILENCE_RMS_THRESHOLD) {
+            return "";
+        }
+
+        await this.ensureReady();
+        return await this.transcribe(samples);
+    }
+
+    /**
+     * @param {Float32Array} audio
+     * @returns {Promise<string>}
+     */
+    async transcribe(audio) {
+        this.ensureWorker();
+        const requestId = this.nextRequestId++;
+        const resultPromise = this.waitForWorker(requestId);
+        this.worker.postMessage({
+            type: "transcribe",
+            requestId,
+            audio,
+            language: WhisperSpeechToText.detectLanguage(),
+        }, [audio.buffer]);
+        const text = await resultPromise;
+        return typeof text === "string" ? text.trim() : "";
+    }
+
+    waitForWorker(requestId) {
+        return new Promise((resolve, reject) => {
+            this.pending.set(requestId, { resolve, reject });
+        });
+    }
+
+    resolvePending(requestId, value) {
+        const pending = this.pending.get(requestId);
+        if (!pending) {
+            return;
+        }
+        this.pending.delete(requestId);
+        pending.resolve(value);
+    }
+
+    rejectPending(requestId, error) {
+        const pending = this.pending.get(requestId);
+        if (!pending) {
+            return;
+        }
+        this.pending.delete(requestId);
+        pending.reject(error);
+    }
+}
+
+const WHISPER_MIN_SAMPLES = Math.round(16000 * MIN_RECORDING_SECONDS);
+
+export { MAX_RECORDING_SECONDS };
+export default WhisperSpeechToText;

--- a/src/frontend/js/whisper-pcm-processor.js
+++ b/src/frontend/js/whisper-pcm-processor.js
@@ -1,0 +1,18 @@
+/**
+ * AudioWorklet processor that forwards raw microphone PCM to the main thread.
+ *
+ * Downsampling to Whisper's 16 kHz input happens after recording stops so this
+ * processor stays allocation-light while the user is speaking.
+ */
+class WhisperPcmProcessor extends AudioWorkletProcessor {
+    process(inputs) {
+        const input = inputs[0];
+        if (input && input.length > 0 && input[0] && input[0].length > 0) {
+            // Copy the samples; the AudioWorklet buffer is reused across callbacks.
+            this.port.postMessage(new Float32Array(input[0]));
+        }
+        return true;
+    }
+}
+
+registerProcessor("whisper-pcm-processor", WhisperPcmProcessor);

--- a/src/frontend/js/whisper.worker.js
+++ b/src/frontend/js/whisper.worker.js
@@ -1,0 +1,111 @@
+/**
+ * Web Worker that runs Whisper Tiny entirely on-device.
+ *
+ * Remote Hugging Face / CDN fetches are disabled. Model weights and ONNX
+ * Runtime WASM files are loaded from Crosstalk's local static assets.
+ */
+
+import { pipeline, env } from "@huggingface/transformers";
+// onnxruntime-web's package exports hide the WASM files, so Vite must load
+// them from the installed dist directory instead of the package name.
+import asyncifyWasmUrl from "../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm?url";
+import asyncifyMjsUrl from "../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs?url";
+import safariWasmUrl from "../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.wasm?url";
+import safariMjsUrl from "../../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs?url";
+
+const MODEL_ID = "Xenova/whisper-tiny";
+
+function isSafari() {
+    if (typeof navigator === "undefined") {
+        return false;
+    }
+    const userAgent = navigator.userAgent;
+    const vendor = navigator.vendor || "";
+    const isAppleVendor = vendor.indexOf("Apple") > -1;
+    const notOtherBrowser = !userAgent.match(/CriOS|FxiOS|EdgiOS|OPiOS|mercury|brave/i)
+        && !userAgent.includes("Chrome")
+        && !userAgent.includes("Android");
+    return isAppleVendor && notOtherBrowser;
+}
+
+// Serve weights and WASM from this origin only. Never fall back to the Hub.
+env.allowLocalModels = true;
+env.allowRemoteModels = false;
+env.localModelPath = "/assets/whisper/models/";
+env.useBrowserCache = true;
+env.backends.onnx.wasm.numThreads = 1;
+env.backends.onnx.wasm.proxy = false;
+env.backends.onnx.wasm.wasmPaths = isSafari()
+    ? {
+        mjs: safariMjsUrl,
+        wasm: safariWasmUrl,
+    }
+    : {
+        mjs: asyncifyMjsUrl,
+        wasm: asyncifyWasmUrl,
+    };
+
+let transcriber = null;
+let loadPromise = null;
+
+async function getTranscriber() {
+    if (transcriber) {
+        return transcriber;
+    }
+    if (!loadPromise) {
+        loadPromise = pipeline("automatic-speech-recognition", MODEL_ID, {
+            dtype: "q8",
+            device: "wasm",
+            progress_callback: (progress) => {
+                self.postMessage({
+                    type: "progress",
+                    progress,
+                });
+            },
+        }).then((instance) => {
+            transcriber = instance;
+            return instance;
+        }).catch((error) => {
+            loadPromise = null;
+            throw error;
+        });
+    }
+    return loadPromise;
+}
+
+self.onmessage = async (event) => {
+    const { type, requestId, audio, language } = event.data || {};
+
+    try {
+        if (type === "load") {
+            await getTranscriber();
+            self.postMessage({ type: "ready", requestId });
+            return;
+        }
+
+        if (type === "transcribe") {
+            const asr = await getTranscriber();
+            const options = {
+                task: "transcribe",
+                return_timestamps: false,
+            };
+            if (language) {
+                options.language = language;
+            }
+            const result = await asr(audio, options);
+            const text = typeof result?.text === "string" ? result.text : "";
+            self.postMessage({
+                type: "result",
+                requestId,
+                text,
+            });
+            return;
+        }
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            requestId,
+            message: error?.message || String(error),
+        });
+    }
+};

--- a/src/frontend/js/whisper.worker.js
+++ b/src/frontend/js/whisper.worker.js
@@ -53,8 +53,11 @@ async function getTranscriber() {
         return transcriber;
     }
     if (!loadPromise) {
+        // Use fp32, not q8: Transformers.js 4.2 + current onnxruntime-web rejects
+        // Xenova/whisper-tiny quantized graphs with MatMulNBits missing-scale errors.
+        // fp32 is the supported local workaround until transformers.js 4.3+.
         loadPromise = pipeline("automatic-speech-recognition", MODEL_ID, {
-            dtype: "q8",
+            dtype: "fp32",
             device: "wasm",
             progress_callback: (progress) => {
                 self.postMessage({

--- a/src/frontend/public/assets/whisper/README.md
+++ b/src/frontend/public/assets/whisper/README.md
@@ -1,0 +1,12 @@
+# On-device Whisper assets
+
+Chat dictation loads Whisper Tiny weights from this directory. The files are
+staged by `npm run download-whisper-assets` during `npm run build-frontend`
+and are then served by Crosstalk's local web server. ONNX Runtime WASM is
+bundled by Vite from `onnxruntime-web`.
+
+Nothing in this folder is uploaded at runtime. Microphone audio stays in the
+browser/Electron process and is transcribed on-device.
+
+Large model and WASM binaries are gitignored. Rebuild the frontend to restore
+them after a fresh clone.

--- a/src/frontend/public/assets/whisper/README.md
+++ b/src/frontend/public/assets/whisper/README.md
@@ -1,12 +1,15 @@
 # On-device Whisper assets
 
-Chat dictation loads Whisper Tiny weights from this directory. The files are
-staged by `npm run download-whisper-assets` during `npm run build-frontend`
+Chat dictation loads Whisper Tiny fp32 weights from this directory. The files
+are staged by `npm run download-whisper-assets` during `npm run build-frontend`
 and are then served by Crosstalk's local web server. ONNX Runtime WASM is
 bundled by Vite from `onnxruntime-web`.
+
+fp32 is intentional: current Transformers.js / ONNX Runtime rejects the older
+quantized Whisper graphs with MatMulNBits missing-scale errors.
 
 Nothing in this folder is uploaded at runtime. Microphone audio stays in the
 browser/Electron process and is transcribed on-device.
 
-Large model and WASM binaries are gitignored. Rebuild the frontend to restore
-them after a fresh clone.
+Large model binaries are gitignored. Rebuild the frontend to restore them after
+a fresh clone.

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,21 @@ export default {
     // vite app is loaded from /src/frontend
     root: path.join(__dirname, "src", "frontend"),
 
+    // Whisper runs in a Web Worker. Transformers.js uses top-level await and
+    // should not be pre-bundled by esbuild.
+    optimizeDeps: {
+        exclude: [
+            "@huggingface/transformers",
+        ],
+    },
+
+    worker: {
+        format: "es",
+    },
+
     build: {
+
+        target: "es2022",
 
         // we want to compile vite app to /public which is bundled and served by the python executable
         outDir: path.join(__dirname, "public"),


### PR DESCRIPTION
## Summary
- Removes the macOS microphone prompt from Electron launch (it previously ran during `loading.html` and blocked startup).
- Adds IPC `ask-for-microphone-access` and `ElectronUtils.ensureMicrophoneAccess()` so capture asks on first use.
- Dictate, Add Voice, and Calls each request access before `getUserMedia`. Denying access stops the action with an alert or toast.

## Why
Launch-time TCC on macOS was confusing and asked for the mic before anything needed it. Access should match the action that uses the microphone.

## Depends on
Stacked on #2 (on-device dictation). Extra commits from that PR will drop out after it merges.

## Test plan
- [ ] Fresh macOS grant/deny: launching Crosstalk does not prompt for the microphone.
- [ ] First Dictate, Add Voice, and Call each prompt (or reuse an existing grant).
- [ ] Deny access: the action stops with a short message instead of failing inside capture.
- [ ] Browser/non-Electron still uses the normal `getUserMedia` prompt.