### PR TITLE
Disable failed Reticulum interfaces on startup instead of exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Improved interface import, export, editing and deletion.
 - Automatic backend restarts after configuration changes.
 - An isolated Crosstalk Reticulum configuration so another local Reticulum instance cannot leave the app using stale settings.
+- Failed interfaces are turned off on startup instead of taking the whole app down. See [Interface startup recovery](./docs/interface_startup.md).
 
 ### Better everyday UI
 

--- a/crosstalk.py
+++ b/crosstalk.py
@@ -34,6 +34,7 @@ from src.backend.async_utils import AsyncUtils
 from src.backend.colour_utils import ColourUtils
 from src.backend.interface_config_parser import InterfaceConfigParser
 from src.backend.interface_editor import InterfaceEditor
+from src.backend.reticulum_startup import start_reticulum
 from src.backend.lxmf_message_fields import LxmfImageField, LxmfFileAttachmentsField, LxmfFileAttachment, LxmfAudioField
 from src.backend.audio_call_manager import AudioCall, AudioCallManager
 from src.backend.satellite_retry_policy import SatelliteRetryPolicy
@@ -229,7 +230,9 @@ class Crosstalk:
         # init reticulum
         ensure_bundled_reticulum_interfaces(reticulum_config_dir)
         ensure_dedicated_reticulum_instance(reticulum_config_dir)
-        self.reticulum = RNS.Reticulum(reticulum_config_dir)
+        self.reticulum, self.interfaces_disabled_on_startup = start_reticulum(
+            reticulum_config_dir
+        )
         # Always collect signed interface advertisements so Crosstalk can show
         # nearby Reticulum infrastructure. Reticulum guards against registering
         # the discovery handler more than once when config already enables it.
@@ -1173,6 +1176,7 @@ class Crosstalk:
                     "reticulum_config_path": self.reticulum.configpath,
                     "is_connected_to_shared_instance": self.reticulum.is_connected_to_shared_instance,
                     "is_transport_enabled": self.reticulum.transport_enabled(),
+                    "interfaces_disabled_on_startup": self.interfaces_disabled_on_startup,
                 },
             })
 

--- a/docs/interface_startup.md
+++ b/docs/interface_startup.md
@@ -1,0 +1,18 @@
+# Interface startup recovery
+
+Reticulum exits the process if a configured interface cannot be created, for
+example when a LAN AutoInterface cannot bind UDP port 42671 because another
+Reticulum app already owns it.
+
+Crosstalk intercepts that failure for a single interface:
+
+1. The failed interface is turned off in the Reticulum config file.
+2. A half-initialized copy is dropped from the live transport list.
+3. Remaining interfaces start normally and the app stays up.
+
+The UI shows an alert naming the interfaces that were turned off. You can turn
+them back on from **Network Interfaces** after fixing the conflict (stop the
+other Reticulum process, or use different AutoInterface ports).
+
+A broken config file, or two interfaces that share the same name, is still
+fatal. Those are not recoverable interface start errors.

--- a/src/backend/reticulum_startup.py
+++ b/src/backend/reticulum_startup.py
@@ -1,0 +1,110 @@
+"""Start Reticulum without aborting Crosstalk when one interface fails.
+
+Reticulum calls ``RNS.panic()`` (``os._exit(255)``) if an interface cannot be
+created. Crosstalk intercepts that only while synthesizing a named interface,
+disables the failed interface in config, and continues with the rest.
+"""
+
+from contextlib import contextmanager
+
+import RNS
+
+
+class ReticulumInterfaceStartupError(RuntimeError):
+    """Raised instead of ``RNS.panic()`` while a single interface is starting."""
+
+
+def disable_interface_in_config(config, interface_name):
+    """Turn off a named interface using the same keys Crosstalk's UI uses."""
+    if config is None:
+        return False
+
+    interfaces = config.get("interfaces") if hasattr(config, "get") else None
+    if not interfaces or interface_name not in interfaces:
+        return False
+
+    interface = interfaces[interface_name]
+    changed = False
+
+    if "enabled" in interface:
+        interface["enabled"] = "false"
+        changed = True
+
+    if "interface_enabled" in interface:
+        interface["interface_enabled"] = "false"
+        changed = True
+
+    if "enabled" not in interface and "interface_enabled" not in interface:
+        interface["interface_enabled"] = "false"
+        changed = True
+
+    return changed
+
+
+def detach_transport_interfaces_named(interface_name):
+    """Drop a half-initialized interface from the live Transport list."""
+    transport = getattr(RNS, "Transport", None)
+    if transport is None or not hasattr(transport, "interfaces"):
+        return
+
+    for interface in list(transport.interfaces):
+        if getattr(interface, "name", None) != interface_name:
+            continue
+        try:
+            interface.online = False
+        except Exception:
+            pass
+        try:
+            transport.remove_interface(interface)
+        except Exception:
+            pass
+
+
+@contextmanager
+def recover_failed_interfaces(disabled_names):
+    """Patch interface synthesis so a failed interface is disabled, not fatal."""
+    original_panic = RNS.panic
+    original_synthesize = RNS.Reticulum._synthesize_interface
+
+    def synthesize_and_disable_on_failure(self, config, name, instance_init=False):
+        def raise_instead_of_exit():
+            raise ReticulumInterfaceStartupError(name)
+
+        RNS.panic = raise_instead_of_exit
+        try:
+            return original_synthesize(self, config, name, instance_init=instance_init)
+        except ReticulumInterfaceStartupError:
+            detach_transport_interfaces_named(name)
+            if disable_interface_in_config(self.config, name):
+                try:
+                    self.config.write()
+                except Exception as error:
+                    RNS.log(
+                        f'Crosstalk could not save the disabled interface "{name}": {error}',
+                        RNS.LOG_ERROR,
+                    )
+            disabled_names.append(name)
+            message = (
+                f'Crosstalk disabled the interface "{name}" because it failed to start. '
+                "The rest of the app will continue."
+            )
+            print(message)
+            RNS.log(message, RNS.LOG_ERROR)
+            return None
+        finally:
+            RNS.panic = original_panic
+
+    RNS.Reticulum._synthesize_interface = synthesize_and_disable_on_failure
+    try:
+        yield
+    finally:
+        RNS.Reticulum._synthesize_interface = original_synthesize
+        RNS.panic = original_panic
+
+
+def start_reticulum(config_dir):
+    """Create a Reticulum instance, disabling interfaces that fail to start."""
+    disabled_names = []
+    with recover_failed_interfaces(disabled_names):
+        reticulum = RNS.Reticulum(config_dir)
+    return reticulum, disabled_names

--- a/src/frontend/components/App.vue
+++ b/src/frontend/components/App.vue
@@ -381,10 +381,23 @@ export default {
             try {
                 const response = await window.axios.get(`/api/v1/app/info`);
                 this.appInfo = response.data.app_info;
+                this.warnAboutDisabledStartupInterfaces();
             } catch(e) {
                 // do nothing if failed to load app info
                 console.log(e);
             }
+        },
+        warnAboutDisabledStartupInterfaces() {
+            const disabled = this.appInfo?.interfaces_disabled_on_startup ?? [];
+            if(disabled.length === 0){
+                return;
+            }
+            const names = disabled.map((name) => `"${name}"`).join(", ");
+            const verb = disabled.length === 1 ? "was" : "were";
+            DialogUtils.alert(
+                `${names} failed to start and ${verb} turned off so Crosstalk could keep running. You can turn ${disabled.length === 1 ? "it" : "them"} back on from Network Interfaces after fixing the conflict.`,
+                { title: disabled.length === 1 ? "Interface turned off" : "Interfaces turned off" },
+            );
         },
         async getConfig() {
             try {

--- a/tests/test_reticulum_startup.py
+++ b/tests/test_reticulum_startup.py
@@ -1,0 +1,126 @@
+import unittest
+
+import RNS
+
+from src.backend.reticulum_startup import (
+    disable_interface_in_config,
+    recover_failed_interfaces,
+)
+
+
+class FakeConfig(dict):
+    def __init__(self, interfaces):
+        super().__init__()
+        self["interfaces"] = interfaces
+        self.writes = 0
+
+    def write(self):
+        self.writes += 1
+
+
+class FakeReticulum:
+    def __init__(self, interfaces):
+        self.config = FakeConfig(interfaces)
+
+
+class ReticulumStartupTest(unittest.TestCase):
+    def test_disable_sets_existing_enabled_keys(self):
+        config = {
+            "interfaces": {
+                "LAN": {
+                    "type": "AutoInterface",
+                    "enabled": "yes",
+                    "interface_enabled": "true",
+                },
+            },
+        }
+
+        self.assertTrue(disable_interface_in_config(config, "LAN"))
+        self.assertEqual(config["interfaces"]["LAN"]["enabled"], "false")
+        self.assertEqual(config["interfaces"]["LAN"]["interface_enabled"], "false")
+
+    def test_disable_adds_interface_enabled_when_missing(self):
+        config = {"interfaces": {"LAN": {"type": "AutoInterface"}}}
+
+        self.assertTrue(disable_interface_in_config(config, "LAN"))
+        self.assertEqual(config["interfaces"]["LAN"]["interface_enabled"], "false")
+
+    def test_disable_ignores_unknown_interface(self):
+        config = {"interfaces": {}}
+        self.assertFalse(disable_interface_in_config(config, "LAN"))
+
+    def test_failed_synthesize_disables_interface_instead_of_exiting(self):
+        real_synthesize = RNS.Reticulum._synthesize_interface
+        real_panic = RNS.panic
+
+        def boom(self, config, name, instance_init=False):
+            RNS.panic()
+
+        RNS.Reticulum._synthesize_interface = boom
+        disabled_names = []
+        reticulum = FakeReticulum({
+            "LAN": {
+                "type": "AutoInterface",
+                "interface_enabled": "true",
+            },
+        })
+
+        try:
+            with recover_failed_interfaces(disabled_names):
+                RNS.Reticulum._synthesize_interface(
+                    reticulum,
+                    reticulum.config["interfaces"]["LAN"],
+                    "LAN",
+                    instance_init=True,
+                )
+        finally:
+            RNS.Reticulum._synthesize_interface = real_synthesize
+
+        self.assertEqual(disabled_names, ["LAN"])
+        self.assertEqual(
+            reticulum.config["interfaces"]["LAN"]["interface_enabled"],
+            "false",
+        )
+        self.assertEqual(reticulum.config.writes, 1)
+        self.assertIs(RNS.panic, real_panic)
+
+    def test_successful_synthesize_leaves_interface_enabled(self):
+        real_synthesize = RNS.Reticulum._synthesize_interface
+        calls = []
+
+        def ok(self, config, name, instance_init=False):
+            calls.append(name)
+            return "started"
+
+        RNS.Reticulum._synthesize_interface = ok
+        disabled_names = []
+        reticulum = FakeReticulum({
+            "LAN": {
+                "type": "AutoInterface",
+                "interface_enabled": "true",
+            },
+        })
+
+        try:
+            with recover_failed_interfaces(disabled_names):
+                result = RNS.Reticulum._synthesize_interface(
+                    reticulum,
+                    reticulum.config["interfaces"]["LAN"],
+                    "LAN",
+                    instance_init=True,
+                )
+        finally:
+            RNS.Reticulum._synthesize_interface = real_synthesize
+
+        self.assertEqual(result, "started")
+        self.assertEqual(calls, ["LAN"])
+        self.assertEqual(disabled_names, [])
+        self.assertEqual(
+            reticulum.config["interfaces"]["LAN"]["interface_enabled"],
+            "true",
+        )
+        self.assertEqual(reticulum.config.writes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reticulum calls `RNS.panic()` (`exit 255`) when a configured interface cannot start (for example AutoInterface UDP bind `Address already in use`).
- Crosstalk now intercepts that failure for a single named interface, turns it off in config, drops any half-initialized copy from Transport, and continues.
- The UI alerts with the names of interfaces that were turned off.

A broken config file, or two interfaces that share the same name, is still fatal.

## Why
A bad LAN/AutoInterface was taking down the whole app. Crosstalk should stay up so the user can fix Network Interfaces.

## Test plan
- [ ] Enable a duplicate AutoInterface on default ports 29716/42671, restart, and confirm the app launches.
- [ ] Confirm the failed interface is saved as disabled and an in-app alert names it.
- [ ] Remaining interfaces still come up.
- [ ] `python -m unittest tests.test_reticulum_startup`