### PR TITLE
Show path availability next to names in the chats list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Clearer navigation, deterministic identicons and improved network-map controls.
 - Consistent in-app dialogs, notifications and status feedback.
 - Better attachment previews, attachment-only messages and mobile chat controls.
+- Path-status dots in the chats list so you can see who currently has a delivery route.
 
 ### Reliability improvements and bug fixes
 

--- a/crosstalk.py
+++ b/crosstalk.py
@@ -2361,6 +2361,7 @@ class Crosstalk:
                     "destination_hash": other_user_hash,
                     "is_unread": self.is_lxmf_conversation_unread(other_user_hash),
                     "failed_messages_count": self.lxmf_conversation_failed_messages_count(other_user_hash),
+                    "has_path": self.destination_has_path(other_user_hash),
                     "lxmf_user_icon": lxmf_user_icon,
                     # we say the conversation was updated when the latest message was created
                     # otherwise this will go crazy when sending a message, as the updated_at on the latest message changes very frequently
@@ -3586,6 +3587,24 @@ class Crosstalk:
             return db_destination_display_name.display_name
 
         return None
+
+    def destination_has_path(self, destination_hash):
+        """
+        Return whether Transport currently has a next-hop path for this LXMF destination.
+
+        This is a local table lookup. It does not request a path from the network, so it
+        is safe to call while listing conversations.
+        """
+
+        try:
+            destination_bytes = bytes.fromhex(destination_hash)
+        except (TypeError, ValueError):
+            return False
+
+        try:
+            return bool(RNS.Transport.has_path(destination_bytes))
+        except Exception:
+            return False
 
     # get name to show for an lxmf conversation
     # currently, this will use the app data from the most recent announce

--- a/docs/chat_path_status.md
+++ b/docs/chat_path_status.md
@@ -1,0 +1,20 @@
+# Chat path status
+
+The Chats list shows a small indicator next to each conversation name:
+
+- A filled green dot means Crosstalk currently has a Reticulum path to that LXMF destination.
+- An empty circle means no path is in the local Transport table.
+
+This is a send-now hint, not a true online/offline signal. A path can linger after a peer goes quiet, and a live peer can show an empty circle until an announce or path request fills the table.
+
+## How it updates
+
+`GET /api/v1/lxmf/conversations` includes `has_path` for each chat. That value comes from `RNS.Transport.has_path()`, which is a local lookup and does not request a path from the network.
+
+The messages page already reloads conversations about every five seconds, so the dots can lag by that much.
+
+## What it does not do
+
+- It does not ping the other client.
+- It does not call `request_path()` while listing chats.
+- It does not replace hop count or signal details in an open conversation.

--- a/src/frontend/components/messages/MessagesSidebar.vue
+++ b/src/frontend/components/messages/MessagesSidebar.vue
@@ -34,7 +34,14 @@
                                 :destination-hash="conversation.destination_hash"/>
                         </div>
                         <div class="min-w-0 flex-1">
-                            <div class="truncate text-sm text-[var(--ct-text)]" :class="{ 'font-bold': conversation.is_unread || conversation.failed_messages_count > 0 }">{{ conversation.custom_display_name ?? conversation.display_name }}</div>
+                            <div class="flex min-w-0 items-center gap-1.5">
+                                <span
+                                    class="size-2.5 shrink-0 rounded-full"
+                                    :class="conversation.has_path ? 'bg-[var(--ct-green)] shadow-[0_0_8px_rgba(46,231,129,0.55)]' : 'border border-[var(--ct-dim)] bg-transparent'"
+                                    :title="pathStatusTitle(conversation.has_path)"
+                                    :aria-label="pathStatusTitle(conversation.has_path)"></span>
+                                <div class="truncate text-sm text-[var(--ct-text)]" :class="{ 'font-bold': conversation.is_unread || conversation.failed_messages_count > 0 }">{{ conversation.custom_display_name ?? conversation.display_name }}</div>
+                            </div>
                             <div class="text-xs text-[var(--ct-dim)]">{{ formatTimeAgo(conversation.updated_at) }}</div>
                         </div>
                         <div v-if="conversation.is_unread" class="ml-2 shrink-0">
@@ -172,6 +179,9 @@ export default {
         },
         formatTimeAgo: function(datetimeString) {
             return Utils.formatTimeAgo(datetimeString);
+        },
+        pathStatusTitle(hasPath) {
+            return hasPath ? "Path available" : "No current path";
         },
     },
     computed: {


### PR DESCRIPTION
## Summary
- Conversations API includes `has_path` from `RNS.Transport.has_path()` (local lookup, no `request_path`).
- The chats list shows a green filled dot when a delivery route exists, or an empty circle when it does not.

## Why
It was hard to tell who currently has an LXMF delivery route without opening the chat.

## Test plan
- [ ] Open the chats list and confirm dots next to names.
- [ ] A peer with a known path shows a filled green dot.
- [ ] A peer with no path shows an empty circle.
- [ ] List refresh still updates the indicator.