### PR TITLE
Probe LXMF delivery when opening a chat with no path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Clearer navigation, deterministic identicons and improved network-map controls.
 - Consistent in-app dialogs, notifications and status feedback.
 - Better attachment previews, attachment-only messages and mobile chat controls.
+- Path-status dots in the chats list so you can see who currently has a delivery route.
 
 ### Reliability improvements and bug fixes
 

--- a/crosstalk.py
+++ b/crosstalk.py
@@ -2361,6 +2361,7 @@ class Crosstalk:
                     "destination_hash": other_user_hash,
                     "is_unread": self.is_lxmf_conversation_unread(other_user_hash),
                     "failed_messages_count": self.lxmf_conversation_failed_messages_count(other_user_hash),
+                    "has_path": self.destination_has_path(other_user_hash),
                     "lxmf_user_icon": lxmf_user_icon,
                     # we say the conversation was updated when the latest message was created
                     # otherwise this will go crazy when sending a message, as the updated_at on the latest message changes very frequently
@@ -3586,6 +3587,24 @@ class Crosstalk:
             return db_destination_display_name.display_name
 
         return None
+
+    def destination_has_path(self, destination_hash):
+        """
+        Return whether Transport currently has a next-hop path for this LXMF destination.
+
+        This is a local table lookup. It does not request a path from the network, so it
+        is safe to call while listing conversations.
+        """
+
+        try:
+            destination_bytes = bytes.fromhex(destination_hash)
+        except (TypeError, ValueError):
+            return False
+
+        try:
+            return bool(RNS.Transport.has_path(destination_bytes))
+        except Exception:
+            return False
 
     # get name to show for an lxmf conversation
     # currently, this will use the app data from the most recent announce

--- a/docs/chat_path_status.md
+++ b/docs/chat_path_status.md
@@ -5,16 +5,20 @@ The Chats list shows a small indicator next to each conversation name:
 - A filled green dot means Crosstalk currently has a Reticulum path to that LXMF destination.
 - An empty circle means no path is in the local Transport table.
 
-This is a send-now hint, not a true online/offline signal. A path can linger after a peer goes quiet, and a live peer can show an empty circle until an announce or path request fills the table.
+This is a send-now hint, not a true online/offline signal. A path can linger after a peer goes quiet, and a live peer can show an empty circle until an announce, a path request, or an on-demand probe fills the table.
 
 ## How it updates
 
 `GET /api/v1/lxmf/conversations` includes `has_path` for each chat. That value comes from `RNS.Transport.has_path()`, which is a local lookup and does not request a path from the network.
 
-The messages page already reloads conversations about every five seconds, so the dots can lag by that much.
+The messages page already reloads conversations about every five seconds, so unopened chats wait for an announce (or other traffic) to populate the path table.
+
+Opening a conversation is different. If that chat has no local path, Crosstalk sends a silent LXMF delivery ping in the background. A successful proof requests/fills the path and refreshes the chats-list dot without waiting for the peer to announce. Message loading is not blocked, and switching chats ignores a late result. Failures stay silent.
 
 ## What it does not do
 
-- It does not ping the other client.
+- It does not ping every chat in the list.
+- It does not ping on launch when no conversation is selected.
 - It does not call `request_path()` while listing chats.
 - It does not replace hop count or signal details in an open conversation.
+- It does not show the manual Ping Destination dialog; that remains a separate, explicit action.

--- a/docs/chat_path_status.md
+++ b/docs/chat_path_status.md
@@ -1,0 +1,20 @@
+# Chat path status
+
+The Chats list shows a small indicator next to each conversation name:
+
+- A filled green dot means Crosstalk currently has a Reticulum path to that LXMF destination.
+- An empty circle means no path is in the local Transport table.
+
+This is a send-now hint, not a true online/offline signal. A path can linger after a peer goes quiet, and a live peer can show an empty circle until an announce or path request fills the table.
+
+## How it updates
+
+`GET /api/v1/lxmf/conversations` includes `has_path` for each chat. That value comes from `RNS.Transport.has_path()`, which is a local lookup and does not request a path from the network.
+
+The messages page already reloads conversations about every five seconds, so the dots can lag by that much.
+
+## What it does not do
+
+- It does not ping the other client.
+- It does not call `request_path()` while listing chats.
+- It does not replace hop count or signal details in an open conversation.

--- a/src/frontend/components/messages/ConversationViewer.vue
+++ b/src/frontend/components/messages/ConversationViewer.vue
@@ -496,6 +496,9 @@ export default {
             isSendingMessage: false,
             autoScrollOnNewMessage: true,
 
+            pathProbeSession: 0,
+            pathProbeInFlight: {},
+
             isRecordingAudioAttachment: false,
             audioAttachmentMicrophoneRecorder: null,
             audioAttachmentMicrophoneRecorderCodec: null,
@@ -524,6 +527,8 @@ export default {
 
         // stop polling satellite signal
         clearInterval(this.satelliteSignalTimer);
+
+        this.pathProbeSession += 1;
 
     },
     mounted() {
@@ -583,13 +588,16 @@ export default {
             this.selectedPeerPath = null;
             this.selectedPeerLxmfStampInfo = null;
             this.selectedPeerSignalMetrics = null;
+            this.pathProbeSession += 1;
             if(!this.selectedPeer){
                 return;
             }
 
-            this.getPeerPath();
             this.getPeerLxmfStampInfo();
             this.getPeerSignalMetrics();
+            this.getPeerPath().then(() => {
+                this.probeReachabilityIfNeeded();
+            });
 
             // load 1 page of previous messages
             await this.loadPrevious();
@@ -773,6 +781,40 @@ export default {
                     this.selectedPeerPath = null;
 
                 }
+            }
+        },
+        /**
+         * When a chat is opened with no local path, probe LXMF delivery so the
+         * path-status dot can update without waiting for an announce.
+         * Unopened chats are left announce-driven. Failures stay silent.
+         */
+        async probeReachabilityIfNeeded() {
+            const destinationHash = this.selectedPeer?.destination_hash;
+            if(!destinationHash || this.selectedPeerPath || this.pathProbeInFlight[destinationHash]){
+                return;
+            }
+
+            const session = this.pathProbeSession;
+            this.pathProbeInFlight[destinationHash] = true;
+
+            try {
+                await window.axios.get(`/api/v1/ping/${destinationHash}/lxmf.delivery`, {
+                    params: {
+                        timeout: 15,
+                    },
+                    timeout: 20000,
+                });
+
+                if(session !== this.pathProbeSession || this.selectedPeer?.destination_hash !== destinationHash){
+                    return;
+                }
+
+                await this.getPeerPath();
+                this.$emit("reload-conversations");
+            } catch(e) {
+                // Peer may be offline, or we may not have recalled their identity yet.
+            } finally {
+                delete this.pathProbeInFlight[destinationHash];
             }
         },
         async getPeerLxmfStampInfo() {
@@ -1805,6 +1847,7 @@ export default {
     },
     watch: {
         selectedPeer() {
+            this.pathProbeSession += 1;
             this.initialLoad();
         },
         async selectedPeerChatItems() {

--- a/src/frontend/components/messages/MessagesSidebar.vue
+++ b/src/frontend/components/messages/MessagesSidebar.vue
@@ -34,7 +34,14 @@
                                 :destination-hash="conversation.destination_hash"/>
                         </div>
                         <div class="min-w-0 flex-1">
-                            <div class="truncate text-sm text-[var(--ct-text)]" :class="{ 'font-bold': conversation.is_unread || conversation.failed_messages_count > 0 }">{{ conversation.custom_display_name ?? conversation.display_name }}</div>
+                            <div class="flex min-w-0 items-center gap-1.5">
+                                <span
+                                    class="size-2.5 shrink-0 rounded-full"
+                                    :class="conversation.has_path ? 'bg-[var(--ct-green)] shadow-[0_0_8px_rgba(46,231,129,0.55)]' : 'border border-[var(--ct-dim)] bg-transparent'"
+                                    :title="pathStatusTitle(conversation.has_path)"
+                                    :aria-label="pathStatusTitle(conversation.has_path)"></span>
+                                <div class="truncate text-sm text-[var(--ct-text)]" :class="{ 'font-bold': conversation.is_unread || conversation.failed_messages_count > 0 }">{{ conversation.custom_display_name ?? conversation.display_name }}</div>
+                            </div>
                             <div class="text-xs text-[var(--ct-dim)]">{{ formatTimeAgo(conversation.updated_at) }}</div>
                         </div>
                         <div v-if="conversation.is_unread" class="ml-2 shrink-0">
@@ -172,6 +179,9 @@ export default {
         },
         formatTimeAgo: function(datetimeString) {
             return Utils.formatTimeAgo(datetimeString);
+        },
+        pathStatusTitle(hasPath) {
+            return hasPath ? "Path available" : "No current path";
         },
     },
     computed: {


### PR DESCRIPTION
## Summary
- When you open a conversation that has no local path, Crosstalk silently pings `GET /api/v1/ping/{hash}/lxmf.delivery` (15s probe, 20s HTTP timeout).
- On success it refreshes the path and reloads the chats list so the path-status dot can update.
- Failures stay silent. Switching chats increments a session counter so late results are ignored.
- Unopened conversations stay announce-driven.

## Why
Unopened chats often stay pathless until something actually tries the destination. Opening the conversation is a reasonable time to check, without waiting for an announce.

## Depends on
Stacked on #5 (path-status dots). Extra commits from that PR will drop out after it merges.

## Test plan
- [ ] Open a chat with no path: after a successful probe the list dot can turn filled without a manual announce.
- [ ] Open a chat with an existing path: no extra ping.
- [ ] Switch chats quickly: a late probe from the previous chat does not apply.
- [ ] Unreachable peer: no error dialog; the empty-circle indicator remains.