### PR TITLE
Warn before adding a duplicate AutoInterface on the default LAN ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Improved interface import, export, editing and deletion.
 - Automatic backend restarts after configuration changes.
 - An isolated Crosstalk Reticulum configuration so another local Reticulum instance cannot leave the app using stale settings.
+- Failed interfaces are turned off on startup instead of taking the whole app down. See [Interface startup recovery](./docs/interface_startup.md).
 
 ### Better everyday UI
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Crosstalk keeps MeshChat's LXMF messaging, attachments, audio calls, propagation
 - Automatic backend restarts after configuration changes.
 - An isolated Crosstalk Reticulum configuration so another local Reticulum instance cannot leave the app using stale settings.
 - Failed interfaces are turned off on startup instead of taking the whole app down. See [Interface startup recovery](./docs/interface_startup.md).
+- Adding Local Network (Auto) warns if an AutoInterface is already enabled, so a second copy does not bind the same LAN ports.
 
 ### Better everyday UI
 

--- a/crosstalk.py
+++ b/crosstalk.py
@@ -34,6 +34,7 @@ from src.backend.async_utils import AsyncUtils
 from src.backend.colour_utils import ColourUtils
 from src.backend.interface_config_parser import InterfaceConfigParser
 from src.backend.interface_editor import InterfaceEditor
+from src.backend.reticulum_startup import start_reticulum
 from src.backend.lxmf_message_fields import LxmfImageField, LxmfFileAttachmentsField, LxmfFileAttachment, LxmfAudioField
 from src.backend.audio_call_manager import AudioCall, AudioCallManager
 from src.backend.satellite_retry_policy import SatelliteRetryPolicy
@@ -229,7 +230,9 @@ class Crosstalk:
         # init reticulum
         ensure_bundled_reticulum_interfaces(reticulum_config_dir)
         ensure_dedicated_reticulum_instance(reticulum_config_dir)
-        self.reticulum = RNS.Reticulum(reticulum_config_dir)
+        self.reticulum, self.interfaces_disabled_on_startup = start_reticulum(
+            reticulum_config_dir
+        )
         # Always collect signed interface advertisements so Crosstalk can show
         # nearby Reticulum infrastructure. Reticulum guards against registering
         # the discovery handler more than once when config already enables it.
@@ -1173,6 +1176,7 @@ class Crosstalk:
                     "reticulum_config_path": self.reticulum.configpath,
                     "is_connected_to_shared_instance": self.reticulum.is_connected_to_shared_instance,
                     "is_transport_enabled": self.reticulum.transport_enabled(),
+                    "interfaces_disabled_on_startup": self.interfaces_disabled_on_startup,
                 },
             })
 

--- a/docs/interface_startup.md
+++ b/docs/interface_startup.md
@@ -14,5 +14,11 @@ The UI shows an alert naming the interfaces that were turned off. You can turn
 them back on from **Network Interfaces** after fixing the conflict (stop the
 other Reticulum process, or use different AutoInterface ports).
 
+When adding **Local Network (Auto)**, Crosstalk checks for an enabled
+AutoInterface that already uses the same group and ports (empty fields mean
+Reticulum's defaults: group `reticulum`, discovery `29716`, data `42671`). The
+type picker marks that existing interface, the form explains that a second
+copy is unnecessary, and Save asks before creating a duplicate.
+
 A broken config file, or two interfaces that share the same name, is still
 fatal. Those are not recoverable interface start errors.

--- a/docs/interface_startup.md
+++ b/docs/interface_startup.md
@@ -1,0 +1,18 @@
+# Interface startup recovery
+
+Reticulum exits the process if a configured interface cannot be created, for
+example when a LAN AutoInterface cannot bind UDP port 42671 because another
+Reticulum app already owns it.
+
+Crosstalk intercepts that failure for a single interface:
+
+1. The failed interface is turned off in the Reticulum config file.
+2. A half-initialized copy is dropped from the live transport list.
+3. Remaining interfaces start normally and the app stays up.
+
+The UI shows an alert naming the interfaces that were turned off. You can turn
+them back on from **Network Interfaces** after fixing the conflict (stop the
+other Reticulum process, or use different AutoInterface ports).
+
+A broken config file, or two interfaces that share the same name, is still
+fatal. Those are not recoverable interface start errors.

--- a/src/backend/reticulum_startup.py
+++ b/src/backend/reticulum_startup.py
@@ -1,0 +1,110 @@
+"""Start Reticulum without aborting Crosstalk when one interface fails.
+
+Reticulum calls ``RNS.panic()`` (``os._exit(255)``) if an interface cannot be
+created. Crosstalk intercepts that only while synthesizing a named interface,
+disables the failed interface in config, and continues with the rest.
+"""
+
+from contextlib import contextmanager
+
+import RNS
+
+
+class ReticulumInterfaceStartupError(RuntimeError):
+    """Raised instead of ``RNS.panic()`` while a single interface is starting."""
+
+
+def disable_interface_in_config(config, interface_name):
+    """Turn off a named interface using the same keys Crosstalk's UI uses."""
+    if config is None:
+        return False
+
+    interfaces = config.get("interfaces") if hasattr(config, "get") else None
+    if not interfaces or interface_name not in interfaces:
+        return False
+
+    interface = interfaces[interface_name]
+    changed = False
+
+    if "enabled" in interface:
+        interface["enabled"] = "false"
+        changed = True
+
+    if "interface_enabled" in interface:
+        interface["interface_enabled"] = "false"
+        changed = True
+
+    if "enabled" not in interface and "interface_enabled" not in interface:
+        interface["interface_enabled"] = "false"
+        changed = True
+
+    return changed
+
+
+def detach_transport_interfaces_named(interface_name):
+    """Drop a half-initialized interface from the live Transport list."""
+    transport = getattr(RNS, "Transport", None)
+    if transport is None or not hasattr(transport, "interfaces"):
+        return
+
+    for interface in list(transport.interfaces):
+        if getattr(interface, "name", None) != interface_name:
+            continue
+        try:
+            interface.online = False
+        except Exception:
+            pass
+        try:
+            transport.remove_interface(interface)
+        except Exception:
+            pass
+
+
+@contextmanager
+def recover_failed_interfaces(disabled_names):
+    """Patch interface synthesis so a failed interface is disabled, not fatal."""
+    original_panic = RNS.panic
+    original_synthesize = RNS.Reticulum._synthesize_interface
+
+    def synthesize_and_disable_on_failure(self, config, name, instance_init=False):
+        def raise_instead_of_exit():
+            raise ReticulumInterfaceStartupError(name)
+
+        RNS.panic = raise_instead_of_exit
+        try:
+            return original_synthesize(self, config, name, instance_init=instance_init)
+        except ReticulumInterfaceStartupError:
+            detach_transport_interfaces_named(name)
+            if disable_interface_in_config(self.config, name):
+                try:
+                    self.config.write()
+                except Exception as error:
+                    RNS.log(
+                        f'Crosstalk could not save the disabled interface "{name}": {error}',
+                        RNS.LOG_ERROR,
+                    )
+            disabled_names.append(name)
+            message = (
+                f'Crosstalk disabled the interface "{name}" because it failed to start. '
+                "The rest of the app will continue."
+            )
+            print(message)
+            RNS.log(message, RNS.LOG_ERROR)
+            return None
+        finally:
+            RNS.panic = original_panic
+
+    RNS.Reticulum._synthesize_interface = synthesize_and_disable_on_failure
+    try:
+        yield
+    finally:
+        RNS.Reticulum._synthesize_interface = original_synthesize
+        RNS.panic = original_panic
+
+
+def start_reticulum(config_dir):
+    """Create a Reticulum instance, disabling interfaces that fail to start."""
+    disabled_names = []
+    with recover_failed_interfaces(disabled_names):
+        reticulum = RNS.Reticulum(config_dir)
+    return reticulum, disabled_names

--- a/src/frontend/components/App.vue
+++ b/src/frontend/components/App.vue
@@ -381,10 +381,23 @@ export default {
             try {
                 const response = await window.axios.get(`/api/v1/app/info`);
                 this.appInfo = response.data.app_info;
+                this.warnAboutDisabledStartupInterfaces();
             } catch(e) {
                 // do nothing if failed to load app info
                 console.log(e);
             }
+        },
+        warnAboutDisabledStartupInterfaces() {
+            const disabled = this.appInfo?.interfaces_disabled_on_startup ?? [];
+            if(disabled.length === 0){
+                return;
+            }
+            const names = disabled.map((name) => `"${name}"`).join(", ");
+            const verb = disabled.length === 1 ? "was" : "were";
+            DialogUtils.alert(
+                `${names} failed to start and ${verb} turned off so Crosstalk could keep running. You can turn ${disabled.length === 1 ? "it" : "them"} back on from Network Interfaces after fixing the conflict.`,
+                { title: disabled.length === 1 ? "Interface turned off" : "Interfaces turned off" },
+            );
         },
         async getConfig() {
             try {

--- a/src/frontend/components/interfaces/AddInterfacePage.vue
+++ b/src/frontend/components/interfaces/AddInterfacePage.vue
@@ -34,6 +34,9 @@
                             <div class="min-w-0">
                                 <div class="text-sm font-semibold text-[var(--ct-text)]">{{ option.name }}</div>
                                 <div class="mt-0.5 text-xs leading-4 text-[var(--ct-dim)]">{{ option.description }}</div>
+                                <div v-if="alreadyEnabledNoticeForType(option.type)" class="mt-1 text-xs font-medium text-[#7db0ff]">
+                                    {{ alreadyEnabledNoticeForType(option.type) }}
+                                </div>
                             </div>
                         </button>
                     </div>
@@ -100,6 +103,20 @@
                                class="block w-full rounded-lg border p-2.5 text-sm"
                                :class="{ 'cursor-not-allowed opacity-60': isEditingInterface }">
                         <FormSubLabel>Interface names must be unique.</FormSubLabel>
+                    </div>
+
+                    <div v-if="!isEditingInterface && newInterfaceType === 'AutoInterface' && enabledAutoInterfaces.length > 0" class="rounded-lg border border-[rgba(110,168,255,0.34)] bg-[rgba(0,97,253,0.09)] p-3 text-sm text-[var(--ct-text)]">
+                        <div class="font-bold">Local discovery is already on</div>
+                        <div class="mt-1 text-[var(--ct-muted)]">
+                            {{ enabledAutoInterfaceNames }} {{ enabledAutoInterfaces.length === 1 ? "is" : "are" }} already finding peers on this WiFi or Ethernet network. Another AutoInterface with the default group and ports will fail to start. Add a second one only if you need a separate mesh.
+                        </div>
+                        <button
+                            v-if="enabledAutoInterfaces.length === 1"
+                            @click="editExistingInterface(enabledAutoInterfaces[0]._name)"
+                            type="button"
+                            class="mt-2 inline-flex items-center rounded-md ct-secondary-button px-2.5 py-1.5 text-sm font-semibold">
+                            Edit {{ enabledAutoInterfaces[0]._name }}
+                        </button>
                     </div>
 
                     <div v-if="newInterfaceType === 'PublicBackboneInterface'" class="rounded-lg border border-[rgba(110,168,255,0.34)] bg-[rgba(0,97,253,0.09)] p-3 text-sm text-[var(--ct-text)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
@@ -910,6 +927,7 @@
 
 <script>
 import Utils from "../../js/Utils";
+import AutoInterfaceUtils from "../../js/AutoInterfaceUtils";
 import DialogUtils from "../../js/DialogUtils";
 import ExpandingSection from "./ExpandingSection.vue";
 import FormLabel from "../forms/FormLabel.vue";
@@ -931,6 +949,7 @@ export default {
             isEditingInterface: false,
 
             config: null,
+            existingInterfaces: {},
 
             comports: [],
 
@@ -1127,6 +1146,13 @@ export default {
             }
             return null;
         },
+        enabledAutoInterfaces() {
+            const excludeName = this.isEditingInterface ? this.newInterfaceName : null;
+            return AutoInterfaceUtils.enabledAutoInterfaces(this.existingInterfaces, excludeName);
+        },
+        enabledAutoInterfaceNames() {
+            return this.enabledAutoInterfaces.map((iface) => `"${iface._name}"`).join(", ");
+        },
     },
     watch: {
         newInterfaceBandwidth: "updateRNodeCalculations",
@@ -1139,6 +1165,7 @@ export default {
 
         this.getConfig();
         this.loadComports();
+        this.loadExistingInterfaces();
 
         // check if we are editing an interface
         const interfaceName = this.$route.query.interface_name;
@@ -1173,6 +1200,31 @@ export default {
                 console.log(e);
             }
         },
+        alreadyEnabledNoticeForType(interfaceType) {
+            if(interfaceType !== "AutoInterface" || this.enabledAutoInterfaces.length === 0){
+                return null;
+            }
+            if(this.enabledAutoInterfaces.length === 1){
+                return `Already on as ${this.enabledAutoInterfaces[0]._name}`;
+            }
+            return `Already on as ${this.enabledAutoInterfaces.map((iface) => iface._name).join(", ")}`;
+        },
+        editExistingInterface(interfaceName) {
+            this.$router.push({
+                name: "interfaces.edit",
+                query: {
+                    interface_name: interfaceName,
+                },
+            });
+        },
+        async loadExistingInterfaces() {
+            try {
+                const response = await window.axios.get(`/api/v1/reticulum/interfaces`);
+                this.existingInterfaces = response.data.interfaces ?? {};
+            } catch(e) {
+                console.log(e);
+            }
+        },
         async loadComports() {
             try {
                 const response = await window.axios.get(`/api/v1/comports`);
@@ -1187,6 +1239,7 @@ export default {
                 // fetch interfaces
                 const response = await window.axios.get(`/api/v1/reticulum/interfaces`);
                 const interfaces = response.data.interfaces;
+                this.existingInterfaces = interfaces ?? {};
 
                 // find interface, else show error and redirect to interfaces
                 const iface = interfaces[interfaceName];
@@ -1304,6 +1357,27 @@ export default {
         },
         async addInterface() {
             try {
+
+                if(this.newInterfaceType === "AutoInterface"){
+                    const conflicting = AutoInterfaceUtils.conflictingEnabledAutoInterface(
+                        this.existingInterfaces,
+                        {
+                            group_id: this.newInterfaceGroupID,
+                            discovery_port: this.newInterfaceDiscoveryPort,
+                            data_port: this.newInterfaceDataPort,
+                        },
+                        this.isEditingInterface ? this.newInterfaceName : null,
+                    );
+                    if(conflicting){
+                        const shouldSave = await DialogUtils.confirm(
+                            `"${conflicting._name}" is already providing local discovery on the same group and ports. Saving another copy will likely fail until one of them is turned off. Save anyway?`,
+                            { title: "Local discovery already enabled", confirmLabel: "Save anyway" },
+                        );
+                        if(!shouldSave){
+                            return;
+                        }
+                    }
+                }
 
                 // process sub interfaces for RNodeMultiInterface
                 let subInterfacesData = null;

--- a/src/frontend/js/AutoInterfaceUtils.js
+++ b/src/frontend/js/AutoInterfaceUtils.js
@@ -1,0 +1,70 @@
+import Utils from "./Utils";
+
+/**
+ * Reticulum AutoInterface defaults. Empty optional fields in Crosstalk mean
+ * these values, so two "blank" LAN interfaces share one UDP mesh.
+ */
+export const AUTO_INTERFACE_DEFAULT_GROUP_ID = "reticulum";
+export const AUTO_INTERFACE_DEFAULT_DISCOVERY_PORT = 29716;
+export const AUTO_INTERFACE_DEFAULT_DATA_PORT = 42671;
+
+function firstPresent(value) {
+    if(value === undefined || value === null){
+        return "";
+    }
+    return String(value).trim();
+}
+
+function portOrDefault(value, fallback) {
+    const parsed = Number(value);
+    if(Number.isFinite(parsed) && parsed > 0){
+        return parsed;
+    }
+    return fallback;
+}
+
+class AutoInterfaceUtils {
+
+    /**
+     * Group, discovery port, and data port that identify one AutoInterface mesh.
+     * Unset fields resolve to Reticulum's defaults.
+     */
+    static meshIdentity(iface) {
+        const groupId = firstPresent(iface?.group_id).toLowerCase() || AUTO_INTERFACE_DEFAULT_GROUP_ID;
+        const discoveryPort = portOrDefault(iface?.discovery_port, AUTO_INTERFACE_DEFAULT_DISCOVERY_PORT);
+        const dataPort = portOrDefault(iface?.data_port, AUTO_INTERFACE_DEFAULT_DATA_PORT);
+        return `${groupId}|${discoveryPort}|${dataPort}`;
+    }
+
+    static withNames(interfaces) {
+        return Object.entries(interfaces ?? {}).map(([name, iface]) => ({
+            ...iface,
+            _name: name,
+        }));
+    }
+
+    static enabledAutoInterfaces(interfaces, excludeName = null) {
+        return this.withNames(interfaces).filter((iface) => {
+            if(iface.type !== "AutoInterface"){
+                return false;
+            }
+            if(excludeName && iface._name === excludeName){
+                return false;
+            }
+            return Utils.isInterfaceEnabled(iface);
+        });
+    }
+
+    /**
+     * First enabled AutoInterface that shares this form's mesh identity.
+     */
+    static conflictingEnabledAutoInterface(interfaces, candidate, excludeName = null) {
+        const candidateIdentity = this.meshIdentity(candidate);
+        return this.enabledAutoInterfaces(interfaces, excludeName).find((iface) => {
+            return this.meshIdentity(iface) === candidateIdentity;
+        }) ?? null;
+    }
+
+}
+
+export default AutoInterfaceUtils;

--- a/tests/test_reticulum_startup.py
+++ b/tests/test_reticulum_startup.py
@@ -1,0 +1,126 @@
+import unittest
+
+import RNS
+
+from src.backend.reticulum_startup import (
+    disable_interface_in_config,
+    recover_failed_interfaces,
+)
+
+
+class FakeConfig(dict):
+    def __init__(self, interfaces):
+        super().__init__()
+        self["interfaces"] = interfaces
+        self.writes = 0
+
+    def write(self):
+        self.writes += 1
+
+
+class FakeReticulum:
+    def __init__(self, interfaces):
+        self.config = FakeConfig(interfaces)
+
+
+class ReticulumStartupTest(unittest.TestCase):
+    def test_disable_sets_existing_enabled_keys(self):
+        config = {
+            "interfaces": {
+                "LAN": {
+                    "type": "AutoInterface",
+                    "enabled": "yes",
+                    "interface_enabled": "true",
+                },
+            },
+        }
+
+        self.assertTrue(disable_interface_in_config(config, "LAN"))
+        self.assertEqual(config["interfaces"]["LAN"]["enabled"], "false")
+        self.assertEqual(config["interfaces"]["LAN"]["interface_enabled"], "false")
+
+    def test_disable_adds_interface_enabled_when_missing(self):
+        config = {"interfaces": {"LAN": {"type": "AutoInterface"}}}
+
+        self.assertTrue(disable_interface_in_config(config, "LAN"))
+        self.assertEqual(config["interfaces"]["LAN"]["interface_enabled"], "false")
+
+    def test_disable_ignores_unknown_interface(self):
+        config = {"interfaces": {}}
+        self.assertFalse(disable_interface_in_config(config, "LAN"))
+
+    def test_failed_synthesize_disables_interface_instead_of_exiting(self):
+        real_synthesize = RNS.Reticulum._synthesize_interface
+        real_panic = RNS.panic
+
+        def boom(self, config, name, instance_init=False):
+            RNS.panic()
+
+        RNS.Reticulum._synthesize_interface = boom
+        disabled_names = []
+        reticulum = FakeReticulum({
+            "LAN": {
+                "type": "AutoInterface",
+                "interface_enabled": "true",
+            },
+        })
+
+        try:
+            with recover_failed_interfaces(disabled_names):
+                RNS.Reticulum._synthesize_interface(
+                    reticulum,
+                    reticulum.config["interfaces"]["LAN"],
+                    "LAN",
+                    instance_init=True,
+                )
+        finally:
+            RNS.Reticulum._synthesize_interface = real_synthesize
+
+        self.assertEqual(disabled_names, ["LAN"])
+        self.assertEqual(
+            reticulum.config["interfaces"]["LAN"]["interface_enabled"],
+            "false",
+        )
+        self.assertEqual(reticulum.config.writes, 1)
+        self.assertIs(RNS.panic, real_panic)
+
+    def test_successful_synthesize_leaves_interface_enabled(self):
+        real_synthesize = RNS.Reticulum._synthesize_interface
+        calls = []
+
+        def ok(self, config, name, instance_init=False):
+            calls.append(name)
+            return "started"
+
+        RNS.Reticulum._synthesize_interface = ok
+        disabled_names = []
+        reticulum = FakeReticulum({
+            "LAN": {
+                "type": "AutoInterface",
+                "interface_enabled": "true",
+            },
+        })
+
+        try:
+            with recover_failed_interfaces(disabled_names):
+                result = RNS.Reticulum._synthesize_interface(
+                    reticulum,
+                    reticulum.config["interfaces"]["LAN"],
+                    "LAN",
+                    instance_init=True,
+                )
+        finally:
+            RNS.Reticulum._synthesize_interface = real_synthesize
+
+        self.assertEqual(result, "started")
+        self.assertEqual(calls, ["LAN"])
+        self.assertEqual(disabled_names, [])
+        self.assertEqual(
+            reticulum.config["interfaces"]["LAN"]["interface_enabled"],
+            "true",
+        )
+        self.assertEqual(reticulum.config.writes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The Add Interface picker marks Local Network (Auto) when an enabled AutoInterface already exists (`Already on as …`).
- The form explains that a second copy with the default group and ports will fail to start, and offers Edit on the existing interface.
- Save confirms when another enabled AutoInterface shares the same mesh identity: group, discovery port, and data port. Empty fields mean Reticulum defaults (`reticulum` / `29716` / `42671`).
- Disabled AutoInterfaces do not count, so a turned-off LAN entry can still be replaced. A second AutoInterface with different ports or group is still allowed.

## Why
Reticulum already enables a default AutoInterface. Adding Local Network (Auto) with empty ports bound 29716/42671 twice and crashed startup.

## Depends on
Stacked on #4 (disable failed interfaces on startup). Extra commits from that PR will drop out after it merges. The warning is still useful on its own; #4 is the recovery path if a duplicate is saved anyway.

## Test plan
- [ ] With the default AutoInterface enabled, Add Interface shows Already on as that name.
- [ ] Choosing Local Network (Auto) shows the banner and Edit shortcut.
- [ ] Saving with empty ports asks to confirm a duplicate.
- [ ] Cancel leaves config unchanged.
- [ ] A second AutoInterface with different discovery/data ports can still be saved.