### PR TITLE
Add ability to block addresses

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -196,6 +196,7 @@ class Crosstalk:
             database.Announce,
             database.CustomDestinationDisplayName,
             database.FavouriteDestination,
+            database.BlockedDestination,
             database.LxmfMessage,
             database.LxmfConversationReadState,
             database.LxmfUserIcon,
@@ -269,6 +270,10 @@ class Crosstalk:
 
         # set a callback for when an lxmf message is received
         self.message_router.register_delivery_callback(self.on_lxmf_delivery)
+
+        # tell lxmf router to ignore messages from blocked destinations
+        for blocked_destination in database.BlockedDestination.select():
+            self.message_router.ignore_destination(bytes.fromhex(blocked_destination.destination_hash))
 
         # update active propagation node
         self.set_active_propagation_node(self.config.lxmf_preferred_propagation_node_destination_hash.get())
@@ -1558,6 +1563,73 @@ class Crosstalk:
             database.FavouriteDestination.delete().where(database.FavouriteDestination.destination_hash == destination_hash).execute()
             return web.json_response({
                 "message": "Favourite has been added!",
+            })
+
+        # serve blocked destinations
+        @routes.get("/api/v1/blocked-destinations")
+        async def index(request):
+
+            # process blocked destinations
+            blocked_destinations = []
+            for blocked_destination in database.BlockedDestination.select().order_by(database.BlockedDestination.created_at.asc()):
+                blocked_destinations.append({
+                    "destination_hash": blocked_destination.destination_hash,
+                    "created_at": blocked_destination.created_at,
+                })
+
+            return web.json_response({
+                "blocked_destinations": blocked_destinations,
+            })
+
+        # block destination
+        @routes.post("/api/v1/blocked-destinations/{destination_hash}")
+        async def index(request):
+
+            # get path params
+            destination_hash = request.match_info.get("destination_hash", "")
+
+            # validate destination hash
+            try:
+                destination_hash_bytes = bytes.fromhex(destination_hash)
+            except ValueError:
+                return web.json_response({
+                    "message": "destination_hash is invalid",
+                }, status=422)
+
+            # upsert blocked destination
+            data = {
+                "destination_hash": destination_hash,
+                "updated_at": datetime.now(timezone.utc),
+            }
+            query = database.BlockedDestination.insert(data)
+            query = query.on_conflict(conflict_target=[database.BlockedDestination.destination_hash], update=data)
+            query.execute()
+
+            # tell lxmf router to ignore messages from this destination
+            self.message_router.ignore_destination(destination_hash_bytes)
+
+            return web.json_response({
+                "message": "Address has been blocked",
+            })
+
+        # unblock destination
+        @routes.delete("/api/v1/blocked-destinations/{destination_hash}")
+        async def index(request):
+
+            # get path params
+            destination_hash = request.match_info.get("destination_hash", "")
+
+            # delete blocked destination
+            database.BlockedDestination.delete().where(database.BlockedDestination.destination_hash == destination_hash).execute()
+
+            # tell lxmf router to stop ignoring messages from this destination
+            try:
+                self.message_router.unignore_destination(bytes.fromhex(destination_hash))
+            except ValueError:
+                pass
+
+            return web.json_response({
+                "message": "Address has been unblocked",
             })
 
         # propagation node status

--- a/database.py
+++ b/database.py
@@ -110,6 +110,19 @@ class FavouriteDestination(BaseModel):
         table_name = "favourite_destinations"
 
 
+class BlockedDestination(BaseModel):
+
+    id = BigAutoField()
+    destination_hash = CharField(unique=True)  # unique destination hash
+
+    created_at = DateTimeField(default=lambda: datetime.now(timezone.utc))
+    updated_at = DateTimeField(default=lambda: datetime.now(timezone.utc))
+
+    # define table name
+    class Meta:
+        table_name = "blocked_destinations"
+
+
 class LxmfMessage(BaseModel):
 
     id = BigAutoField()

--- a/src/frontend/components/messages/ConversationDropDownMenu.vue
+++ b/src/frontend/components/messages/ConversationDropDownMenu.vue
@@ -35,6 +35,16 @@
                 <span>Set Custom Display Name</span>
             </DropDownMenuItem>
 
+            <!-- block/unblock address button -->
+            <div class="border-t">
+                <DropDownMenuItem @click="onToggleBlocked">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5 text-red-500">
+                        <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-8.25 9.75a8.25 8.25 0 0 1 13.36-6.492L5.508 17.11A8.213 8.213 0 0 1 3.75 12Zm8.25 8.25a8.213 8.213 0 0 1-5.108-1.758L18.492 6.89A8.25 8.25 0 0 1 12 20.25Z" clip-rule="evenodd" />
+                    </svg>
+                    <span class="text-red-500">{{ isBlocked ? "Unblock Address" : "Block Address" }}</span>
+                </DropDownMenuItem>
+            </div>
+
             <!-- delete message history button -->
             <div class="border-t">
                 <DropDownMenuItem @click="onDeleteMessageHistory">
@@ -69,7 +79,59 @@ export default {
         "conversation-deleted",
         "set-custom-display-name",
     ],
+    data() {
+        return {
+            isBlocked: false,
+        };
+    },
+    mounted() {
+        this.getBlockedState();
+    },
+    watch: {
+        "peer.destination_hash"() {
+            this.getBlockedState();
+        },
+    },
     methods: {
+        async getBlockedState() {
+            try {
+                const response = await window.axios.get("/api/v1/blocked-destinations");
+                this.isBlocked = response.data.blocked_destinations.some((blockedDestination) => {
+                    return blockedDestination.destination_hash === this.peer.destination_hash;
+                });
+            } catch(e) {
+                // do nothing if failed to load blocked destinations
+                console.log(e);
+            }
+        },
+        async onToggleBlocked() {
+
+            // unblock without confirmation
+            if(this.isBlocked){
+                try {
+                    await window.axios.delete(`/api/v1/blocked-destinations/${this.peer.destination_hash}`);
+                    this.isBlocked = false;
+                } catch(e) {
+                    DialogUtils.alert("failed to unblock address");
+                    console.log(e);
+                }
+                return;
+            }
+
+            // ask user to confirm blocking address
+            if(!await DialogUtils.confirm("Are you sure you want to block this address? You will no longer receive messages from it. You can unblock it later from this menu or from Settings.", { title: "Block Address", danger: true, confirmLabel: "Block" })){
+                return;
+            }
+
+            try {
+                await window.axios.post(`/api/v1/blocked-destinations/${this.peer.destination_hash}`);
+                this.isBlocked = true;
+            } catch(e) {
+                DialogUtils.alert("failed to block address");
+                console.log(e);
+            }
+
+        },
         async onDeleteMessageHistory() {
 
             // ask user to confirm deleting conversation history

--- a/src/frontend/components/settings/SettingsPage.vue
+++ b/src/frontend/components/settings/SettingsPage.vue
@@ -82,6 +82,23 @@
                 </div>
             </div>
 
+            <!-- blocked addresses -->
+            <div class="ct-card">
+                <div class="flex border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">Blocked Addresses</div>
+                <div class="divide-y divide-[var(--ct-border)] text-[var(--ct-muted)]">
+
+                    <div v-if="blockedDestinations.length === 0" class="p-2.5 text-sm text-[var(--ct-dim)]">
+                        No blocked addresses. You can block an address from a conversation's menu to stop receiving messages from it.
+                    </div>
+
+                    <div v-for="blockedDestination in blockedDestinations" :key="blockedDestination.destination_hash" class="flex items-center gap-x-2.5 p-2.5">
+                        <span class="ct-hash mr-auto text-sm">{{ blockedDestination.destination_hash }}</span>
+                        <button @click="onUnblockDestination(blockedDestination.destination_hash)" type="button" class="ct-secondary-button rounded-lg px-2.5 py-1.5 text-sm font-semibold">Unblock</button>
+                    </div>
+
+                </div>
+            </div>
+
             <!-- message delivery / propagation nodes -->
             <div class="ct-card">
                 <div class="flex items-center border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">
@@ -156,6 +173,7 @@ export default {
                 lxmf_local_propagation_node_enabled: null,
                 lxmf_preferred_propagation_node_destination_hash: null,
             },
+            blockedDestinations: [],
         };
     },
     beforeUnmount() {
@@ -170,6 +188,7 @@ export default {
         WebSocketConnection.on("message", this.onWebsocketMessage);
 
         this.getConfig();
+        this.getBlockedDestinations();
 
     },
     methods: {
@@ -197,6 +216,24 @@ export default {
                 this.config = response.data.config;
             } catch(e) {
                 DialogUtils.toast("Failed to save settings", "error");
+                console.log(e);
+            }
+        },
+        async getBlockedDestinations() {
+            try {
+                const response = await window.axios.get("/api/v1/blocked-destinations");
+                this.blockedDestinations = response.data.blocked_destinations;
+            } catch(e) {
+                // do nothing if failed to load blocked destinations
+                console.log(e);
+            }
+        },
+        async onUnblockDestination(destinationHash) {
+            try {
+                await window.axios.delete(`/api/v1/blocked-destinations/${destinationHash}`);
+                await this.getBlockedDestinations();
+            } catch(e) {
+                DialogUtils.toast("Failed to unblock address", "error");
                 console.log(e);
             }
         },


### PR DESCRIPTION
Adds blocking for users spamming with automated or abusive messages.

A Block Address option in the conversation dropdown blocks the sender after a confirm dialog, and switches to Unblock Address when blocked. Settings gets a Blocked Addresses card listing all blocked hashes with unblock buttons, so you can still unblock after deleting the conversation.

Blocked hashes are stored in a new blocked_destinations table and loaded into the LXMF router's ignore list on startup. The router drops inbound messages from ignored sources natively, so no custom filtering is needed. Endpoints: GET, POST and DELETE on /api/v1/blocked-destinations.

Tested locally: block, unblock and validation endpoints, persistence across restart, and the full UI flow in both the dropdown and Settings.