### PR TITLE
Add inbound stamp cost option

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -265,7 +265,12 @@ class Crosstalk:
         self.local_lxmf_destination = self.message_router.register_delivery_identity(
             identity=self.identity,
             display_name=self.config.display_name.get(),
+            stamp_cost=self.config.lxmf_inbound_stamp_cost.get(),
         )
+
+        # drop inbound messages without a valid stamp if enforcement is enabled
+        if self.config.lxmf_enforce_inbound_stamp_cost.get():
+            self.message_router.enforce_stamps()
 
         # set a callback for when an lxmf message is received
         self.message_router.register_delivery_callback(self.on_lxmf_delivery)
@@ -2486,6 +2491,20 @@ class Crosstalk:
             value = bool(data["show_suggested_community_interfaces"])
             self.config.show_suggested_community_interfaces.set(value)
 
+        if "lxmf_inbound_stamp_cost" in data:
+            value = int(data["lxmf_inbound_stamp_cost"])
+            if 0 <= value <= 254:
+                self.config.lxmf_inbound_stamp_cost.set(value)
+                self.message_router.set_inbound_stamp_cost(self.local_lxmf_destination.hash, value)
+
+        if "lxmf_enforce_inbound_stamp_cost" in data:
+            value = bool(data["lxmf_enforce_inbound_stamp_cost"])
+            self.config.lxmf_enforce_inbound_stamp_cost.set(value)
+            if value:
+                self.message_router.enforce_stamps()
+            else:
+                self.message_router.ignore_stamps()
+
         if "lxmf_preferred_propagation_node_destination_hash" in data:
 
             # update config value
@@ -2741,6 +2760,8 @@ class Crosstalk:
             "allow_auto_resending_failed_messages_with_attachments": self.config.allow_auto_resending_failed_messages_with_attachments.get(),
             "auto_send_failed_messages_to_propagation_node": self.config.auto_send_failed_messages_to_propagation_node.get(),
             "show_suggested_community_interfaces": self.config.show_suggested_community_interfaces.get(),
+            "lxmf_inbound_stamp_cost": self.config.lxmf_inbound_stamp_cost.get(),
+            "lxmf_enforce_inbound_stamp_cost": self.config.lxmf_enforce_inbound_stamp_cost.get(),
             "lxmf_local_propagation_node_enabled": self.config.lxmf_local_propagation_node_enabled.get(),
             "lxmf_local_propagation_node_address_hash": self.message_router.propagation_destination.hexhash,
             "lxmf_preferred_propagation_node_destination_hash": self.config.lxmf_preferred_propagation_node_destination_hash.get(),
@@ -3799,6 +3820,8 @@ class Config:
     show_suggested_community_interfaces = BoolConfig("show_suggested_community_interfaces", True)
     default_rmap_world_interface_seeded = BoolConfig("default_rmap_world_interface_seeded", False)
     lxmf_delivery_transfer_limit_in_bytes = IntConfig("lxmf_delivery_transfer_limit_in_bytes", 1000 * 1000 * 10)  # 10MB
+    lxmf_inbound_stamp_cost = IntConfig("lxmf_inbound_stamp_cost", 0)  # 0 = disabled, valid range 1-254
+    lxmf_enforce_inbound_stamp_cost = BoolConfig("lxmf_enforce_inbound_stamp_cost", False)
     lxmf_preferred_propagation_node_destination_hash = StringConfig("lxmf_preferred_propagation_node_destination_hash", None)
     lxmf_preferred_propagation_node_auto_sync_interval_seconds = IntConfig("lxmf_preferred_propagation_node_auto_sync_interval_seconds", 0)
     lxmf_preferred_propagation_node_last_synced_at = IntConfig("lxmf_preferred_propagation_node_last_synced_at", None)

--- a/src/frontend/components/settings/SettingsPage.vue
+++ b/src/frontend/components/settings/SettingsPage.vue
@@ -79,6 +79,22 @@
                         </label>
                     </div>
 
+                    <div class="p-2.5 space-y-1">
+                        <div class="text-sm font-medium text-[var(--ct-text)]">Inbound Stamp Cost</div>
+                        <input v-model="config.lxmf_inbound_stamp_cost" @change="onLxmfInboundStampCostChange" type="number" min="0" max="254" class="block w-full rounded-lg border p-2.5 text-sm">
+                        <div class="text-sm text-[var(--ct-dim)]">Senders must attach a proof of work stamp of this difficulty to message you, which deters automated spam. 0 disables it. Higher values take senders longer to compute. Peers learn your cost from your next announce.</div>
+                    </div>
+
+                    <div class="p-2.5">
+                        <label class="flex cursor-pointer items-start gap-x-2.5">
+                            <input v-model="config.lxmf_enforce_inbound_stamp_cost" @change="onLxmfEnforceInboundStampCostChange" type="checkbox" class="mt-0.5 size-4 rounded border">
+                            <span>
+                                <span class="block text-sm font-medium text-[var(--ct-text)]">Require Valid Stamps</span>
+                                <span class="block text-sm text-[var(--ct-dim)]">Messages without a valid stamp will be dropped. When disabled, your stamp cost is advertised but unstamped messages are still delivered.</span>
+                            </span>
+                        </label>
+                    </div>
+
                 </div>
             </div>
 
@@ -213,6 +229,16 @@ export default {
         async onAutoSendFailedMessagesToPropagationNodeChange() {
             await this.updateConfig({
                 "auto_send_failed_messages_to_propagation_node": this.config.auto_send_failed_messages_to_propagation_node,
+            });
+        },
+        async onLxmfInboundStampCostChange() {
+            await this.updateConfig({
+                "lxmf_inbound_stamp_cost": this.config.lxmf_inbound_stamp_cost,
+            });
+        },
+        async onLxmfEnforceInboundStampCostChange() {
+            await this.updateConfig({
+                "lxmf_enforce_inbound_stamp_cost": this.config.lxmf_enforce_inbound_stamp_cost,
             });
         },
         async onShowSuggestedCommunityInterfacesChange() {


### PR DESCRIPTION
Adds spam deterrence using LXMF's proof of work stamps.

A new Inbound Stamp Cost setting (0 to 254, 0 disables) advertises a stamp cost in your announces, so stamp-aware clients compute a proof of work before messaging you. A separate Require Valid Stamps checkbox controls enforcement: off by default, meaning the cost is advertised but unstamped messages still arrive. When on, the router drops messages without a valid stamp before they reach the app.

Both settings apply live through the existing config endpoint, no restart needed. Out of range values are rejected. Values persist and load into the router at startup.

Note on enforcement: clients that do not support stamps send without one, so enabling Require Valid Stamps silently cuts off senders on older clients. That is why it defaults to off.

Tested: config roundtrip and validation, persistence across restart, live apply, and the settings UI.