### PR TITLE
Use the app logo as the window icon on Linux and Windows

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -233,6 +233,7 @@ app.whenReady().then(async () => {
         mainWindow = new BrowserWindow({
             width: 1500,
             height: 800,
+            icon: path.join(__dirname, "build/icon.png"), // window/taskbar icon on linux and windows
             webPreferences: {
                 // used to inject logging over ipc
                 preload: path.join(__dirname, 'preload.js'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "crosstalk",
   "version": "2.5.2",
+  "desktopName": "crosstalk",
   "description": "Field-focused Reticulum messaging with native Iridium IMT support",
   "author": "Build with Parallel",
   "repository": "https://github.com/buildwithparallel/crosstalk",
@@ -76,6 +77,8 @@
     "linux": {
       "artifactName": "Crosstalk-v${version}-Linux.${ext}",
       "target": "AppImage",
+      "category": "Network",
+      "syncDesktopName": true,
       "extraFiles": [
         {
           "from": "build/exe",


### PR DESCRIPTION
The packaged app showed the default Electron icon in the taskbar and window on Linux, since those come from the BrowserWindow icon at runtime, not from electron-builder.

Sets the BrowserWindow icon to the bundled logo, which fixes Linux and Windows. Also adds desktopName with linux.syncDesktopName and a Network menu category, which fixes window association for installed desktop entries and clears two electron-builder warnings.

Tested on a Linux desktop: the taskbar entry now shows the Crosstalk logo instead of the Electron default.