### PR TITLE
Fix silent message loss in frozen builds during stamp validation

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 
+import multiprocessing
+
+# required for multiprocessing to work in frozen builds (e.g. lxmf stamp validation worker pools)
+# without it, worker processes re-run the app instead of bootstrapping, which hangs the pool
+# must run before other imports so worker processes exit into their bootstrap immediately
+multiprocessing.freeze_support()
+
 import argparse
 import io
 import json


### PR DESCRIPTION
LXMF validates propagation stamps in a multiprocessing worker pool. In frozen builds (cx_Freeze) the worker processes crashed on circular imports and hung the pool forever. The cruel part: propagation transfers complete at the link level before validation runs, so senders saw success while recipients silently lost the whole batch.

Fix is one line: call multiprocessing.freeze_support() before other imports, which is the documented cx_Freeze requirement. Worker processes then bootstrap correctly instead of re-running the app.

Reproduced with a standalone frozen test app calling LXStamper.validate_pn_stamps with 300 entries: without the call it hangs indefinitely with repeated circular import errors, with it the pool completes cleanly. Also verified on a live desktop build syncing propagation messages, where the errors went from 44 to zero and previously lost messages arrived.

Only frozen builds are affected. Running from source never had the bug, which is why it survived testing.