### PR TITLE
Hide blocked conversations from the chats list

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -2459,6 +2459,9 @@ class Crosstalk:
             # execute sql query
             cursor = database.database.execute_sql(query)
 
+            # get blocked destination hashes, so we can hide conversations with blocked users
+            blocked_destination_hashes = set(blocked_destination.destination_hash for blocked_destination in database.BlockedDestination.select())
+
             # parse results to get a list of conversations we have sent or received a message from
             conversations = []
             for row in cursor.fetchall():
@@ -2473,6 +2476,10 @@ class Crosstalk:
                     other_user_hash = destination_hash
                 else:
                     other_user_hash = source_hash
+
+                # skip conversations with blocked users
+                if other_user_hash in blocked_destination_hashes:
+                    continue
 
                 # find lxmf user icon from database
                 lxmf_user_icon = None

--- a/src/frontend/components/messages/ConversationDropDownMenu.vue
+++ b/src/frontend/components/messages/ConversationDropDownMenu.vue
@@ -78,6 +78,7 @@ export default {
     emits: [
         "conversation-deleted",
         "set-custom-display-name",
+        "blocked-changed",
     ],
     data() {
         return {
@@ -111,6 +112,7 @@ export default {
                 try {
                     await window.axios.delete(`/api/v1/blocked-destinations/${this.peer.destination_hash}`);
                     this.isBlocked = false;
+                    this.$emit("blocked-changed", false);
                 } catch(e) {
                     DialogUtils.alert("failed to unblock address");
                     console.log(e);
@@ -126,6 +128,7 @@ export default {
             try {
                 await window.axios.post(`/api/v1/blocked-destinations/${this.peer.destination_hash}`);
                 this.isBlocked = true;
+                this.$emit("blocked-changed", true);
             } catch(e) {
                 DialogUtils.alert("failed to block address");
                 console.log(e);

--- a/src/frontend/components/messages/ConversationViewer.vue
+++ b/src/frontend/components/messages/ConversationViewer.vue
@@ -91,6 +91,7 @@
                     v-if="selectedPeer"
                     :peer="selectedPeer"
                     @conversation-deleted="onConversationDeleted"
+                    @blocked-changed="onBlockedChanged"
                     @set-custom-display-name="updateCustomDisplayName"/>
             </div>
 
@@ -967,6 +968,17 @@ export default {
             } catch(e) {
                 console.log(e);
                 DialogUtils.alert("Failed to update display name");
+            }
+
+        },
+        async onBlockedChanged(isBlocked) {
+
+            // reload conversations so blocked conversations are hidden from the sidebar
+            this.$emit("reload-conversations");
+
+            // close the conversation when the user was blocked
+            if(isBlocked){
+                this.close();
             }
 
         },


### PR DESCRIPTION
Follow-up to the Block Address feature. Blocking stopped new messages, but the conversation stayed in the Chats list until you also deleted its message history.

The conversations endpoint now skips peers in the blocked list. Blocking from the dropdown closes the open chat and refreshes the sidebar immediately. Message history is preserved, so unblocking from Settings brings the whole conversation back.

Tested in the UI: block from the dropdown, chat closes and disappears from the sidebar. Unblock restores it with history.