### PR TITLE
Add a clear network caches button to settings

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -2110,6 +2110,27 @@ class Crosstalk:
             })
 
         # get Reticulum infrastructure discovered from signed interface advertisements
+        # clear cached network data so discover and the map only show what is heard on current interfaces
+        @routes.post("/api/v1/network-caches/clear")
+        async def index(request):
+
+            # delete all cached announces
+            database.Announce.delete().execute()
+
+            # delete cached interface discovery records from rns storage
+            # rns reads these files on every listing, so no restart is needed
+            discovery_path = os.path.join(RNS.Reticulum.storagepath, "discovery", "interfaces")
+            if os.path.isdir(discovery_path):
+                for filename in os.listdir(discovery_path):
+                    try:
+                        os.remove(os.path.join(discovery_path, filename))
+                    except OSError:
+                        pass
+
+            return web.json_response({
+                "message": "Network caches cleared",
+            })
+
         @routes.get("/api/v1/discovered-interfaces")
         async def index(request):
 

--- a/src/frontend/components/settings/SettingsPage.vue
+++ b/src/frontend/components/settings/SettingsPage.vue
@@ -41,6 +41,14 @@
                         </label>
                     </div>
 
+                    <div class="flex items-center gap-x-2.5 p-2.5">
+                        <span class="mr-auto">
+                            <span class="block text-sm font-medium text-[var(--ct-text)]">Clear Network Caches</span>
+                            <span class="block text-sm text-[var(--ct-dim)]">Removes all cached announces and discovered interfaces, so Discover and the Map only show what is heard on your current connections. They repopulate as announces are received.</span>
+                        </span>
+                        <button @click="onClearNetworkCaches" type="button" class="ct-secondary-button shrink-0 rounded-lg px-2.5 py-1.5 text-sm font-semibold">Clear</button>
+                    </div>
+
                 </div>
             </div>
 
@@ -277,6 +285,22 @@ export default {
             await this.updateConfig({
                 "lxmf_enforce_inbound_stamp_cost": this.config.lxmf_enforce_inbound_stamp_cost,
             });
+        },
+        async onClearNetworkCaches() {
+
+            // ask user to confirm clearing network caches
+            if(!await DialogUtils.confirm("Are you sure you want to clear all cached announces and discovered interfaces? They will repopulate as announces are received on your current connections.", { title: "Clear Network Caches", danger: true, confirmLabel: "Clear" })){
+                return;
+            }
+
+            try {
+                await window.axios.post("/api/v1/network-caches/clear");
+                DialogUtils.toast("Network caches cleared");
+            } catch(e) {
+                DialogUtils.toast("Failed to clear network caches", "error");
+                console.log(e);
+            }
+
         },
         async onShowSuggestedCommunityInterfacesChange() {
             await this.updateConfig({


### PR DESCRIPTION
Cached announces and discovered interfaces accumulate forever with no way to clear them. After switching networks, for example from internet backbones to LoRa only, Discover and the Map keep showing hundreds of stale peers and interfaces from the old network. On my system that was 13k announces and 438 discovered interfaces with no way to remove them.

Adds POST /api/v1/network-caches/clear and a Clear Network Caches button in Settings under Connections, behind a confirm dialog. It empties the announces table and the RNS interface discovery records. RNS reads the discovery records from disk on every listing, so the map clears immediately with no restart. Both caches repopulate as announces are received on current connections.

Tested on a dev instance with seeded cache entries and on a live desktop profile with the real thing.