### PR TITLE
Add path lookup and live activity diagnostics tools

### DIFF
--- a/src/frontend/components/tools/PathLookupPage.vue
+++ b/src/frontend/components/tools/PathLookupPage.vue
@@ -1,0 +1,79 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Path Lookup</div>
+                <div class="text-sm text-[var(--ct-dim)]">See if a path to a destination is known, how many hops away it is, and which interface traffic will leave on. Reticulum only reveals the next hop, never the full route.</div>
+            </div>
+
+            <!-- lookup form -->
+            <div class="ct-card p-2.5 space-y-2">
+                <div class="text-sm font-medium text-[var(--ct-text)]">Destination Hash</div>
+                <input v-model="destinationHash" :disabled="isLoading" type="text" placeholder="e.g: a39610c89d18bb48c73e429582423c24" class="ct-hash block w-full rounded-lg border p-2.5">
+                <div class="flex gap-x-2">
+                    <button @click="lookupPath(false)" :disabled="isLoading || !cleanedDestinationHash" type="button" class="ct-brand-button rounded-lg px-2.5 py-1.5 text-sm font-semibold disabled:opacity-50">Check Path</button>
+                    <button @click="lookupPath(true)" :disabled="isLoading || !cleanedDestinationHash" type="button" class="ct-secondary-button rounded-lg px-2.5 py-1.5 text-sm font-semibold disabled:opacity-50">Request from Network</button>
+                </div>
+                <div v-if="isLoading" class="text-sm text-[var(--ct-dim)]">{{ isRequesting ? "Requesting path from the network, this can take a while on slow links..." : "Checking..." }}</div>
+            </div>
+
+            <!-- result -->
+            <div v-if="result" class="ct-card">
+                <div class="flex border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">Result</div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+                    <div v-if="result.path == null" class="p-2.5">
+                        No path known to this destination. It may be offline, out of range, or may not have announced yet. Try "Request from Network", or wait for an announce.
+                    </div>
+                    <template v-else>
+                        <div class="flex p-2.5"><span class="w-40 shrink-0 font-medium text-[var(--ct-text)]">Hops</span><span>{{ result.path.hops }}</span></div>
+                        <div class="flex p-2.5"><span class="w-40 shrink-0 font-medium text-[var(--ct-text)]">Next Hop</span><span class="ct-hash break-all">{{ result.path.next_hop }}</span></div>
+                        <div class="flex p-2.5"><span class="w-40 shrink-0 font-medium text-[var(--ct-text)]">Via Interface</span><span>{{ result.path.next_hop_interface }}</span></div>
+                    </template>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'PathLookupPage',
+    data() {
+        return {
+            destinationHash: "",
+            isLoading: false,
+            isRequesting: false,
+            result: null,
+        };
+    },
+    computed: {
+        cleanedDestinationHash() {
+            // strip whitespace and angle brackets so pasted "<hash>" values work
+            return this.destinationHash.replace(/[<>\s]/g, "");
+        },
+    },
+    methods: {
+        async lookupPath(requestFromNetwork) {
+            this.isLoading = true;
+            this.isRequesting = requestFromNetwork;
+            this.result = null;
+            try {
+                const response = await window.axios.get(`/api/v1/destination/${this.cleanedDestinationHash}/path`, {
+                    params: requestFromNetwork ? { request: "true", timeout: 30 } : {},
+                    timeout: 60000,
+                });
+                this.result = response.data;
+            } catch(e) {
+                console.log(e);
+                this.result = { path: null };
+            } finally {
+                this.isLoading = false;
+                this.isRequesting = false;
+            }
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/RfActivityPage.vue
+++ b/src/frontend/components/tools/RfActivityPage.vue
@@ -1,0 +1,109 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Live Activity</div>
+                <div class="text-sm text-[var(--ct-dim)]">Watch announces arrive in real time. Entries with signal readings were heard over radio. Leave this page open to confirm your interfaces are receiving.</div>
+            </div>
+
+            <!-- interfaces -->
+            <div class="ct-card">
+                <div class="flex border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">Interfaces</div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+                    <div v-if="interfaces.length === 0" class="p-2.5 text-[var(--ct-dim)]">No interface stats available.</div>
+                    <div v-for="iface in interfaces" :key="iface.name" class="flex items-center gap-x-2.5 p-2.5">
+                        <span class="size-2.5 shrink-0 rounded-full" :class="iface.status ? 'bg-[var(--ct-green)]' : 'border border-[var(--ct-dim)]'"></span>
+                        <span class="mr-auto font-medium text-[var(--ct-text)]">{{ iface.name }}</span>
+                        <span class="text-[var(--ct-dim)]">RX {{ formatBytes(iface.rxb) }}</span>
+                        <span class="text-[var(--ct-dim)]">TX {{ formatBytes(iface.txb) }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- announce feed -->
+            <div class="ct-card">
+                <div class="flex items-center border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">
+                    <span class="mr-auto">Announces</span>
+                    <span class="text-sm font-normal text-[var(--ct-dim)]">{{ announces.length }} heard since opening</span>
+                </div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+                    <div v-if="announces.length === 0" class="p-2.5 text-[var(--ct-dim)]">
+                        Nothing heard yet. Announces will appear here as they arrive. Ask a peer to announce, or wait.
+                    </div>
+                    <div v-for="announce in announces" :key="announce.key" class="p-2.5">
+                        <div class="flex items-center gap-x-2">
+                            <span v-if="announce.rssi != null" class="shrink-0 rounded bg-[rgba(46,231,129,0.15)] px-1.5 py-0.5 text-xs font-semibold text-[var(--ct-green)]">RF</span>
+                            <span class="truncate font-medium text-[var(--ct-text)]">{{ announce.display_name ?? "Anonymous" }}</span>
+                            <span class="shrink-0 text-xs text-[var(--ct-dim)]">{{ announce.aspect }}</span>
+                            <span class="ml-auto shrink-0 text-xs text-[var(--ct-dim)]">{{ announce.time }}</span>
+                        </div>
+                        <div class="ct-hash truncate text-xs text-[var(--ct-dim)]">{{ announce.destination_hash }}</div>
+                        <div class="flex gap-x-3 text-xs text-[var(--ct-dim)]">
+                            <span v-if="announce.hops != null">{{ announce.hops }} {{ announce.hops === 1 ? "hop" : "hops" }}</span>
+                            <span v-if="announce.rssi != null">RSSI {{ announce.rssi }}dBm</span>
+                            <span v-if="announce.snr != null">SNR {{ announce.snr }}dB</span>
+                            <span v-if="announce.quality != null">Quality {{ announce.quality }}%</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+import WebSocketConnection from "../../js/WebSocketConnection";
+import Utils from "../../js/Utils";
+
+export default {
+    name: 'RfActivityPage',
+    data() {
+        return {
+            announces: [],
+            interfaces: [],
+            statsInterval: null,
+        };
+    },
+    mounted() {
+        WebSocketConnection.on("message", this.onWebsocketMessage);
+        this.getInterfaceStats();
+        this.statsInterval = setInterval(this.getInterfaceStats, 2000);
+    },
+    beforeUnmount() {
+        WebSocketConnection.off("message", this.onWebsocketMessage);
+        clearInterval(this.statsInterval);
+    },
+    methods: {
+        onWebsocketMessage(message) {
+            const json = JSON.parse(message.data);
+            if(json.type !== "announce"){
+                return;
+            }
+            this.announces.unshift({
+                key: `${json.announce.destination_hash}-${Date.now()}-${this.announces.length}`,
+                time: new Date().toLocaleTimeString(),
+                ...json.announce,
+            });
+            // keep the feed bounded so long sessions don't grow memory forever
+            if(this.announces.length > 200){
+                this.announces.pop();
+            }
+        },
+        async getInterfaceStats() {
+            try {
+                const response = await window.axios.get("/api/v1/interface-stats");
+                this.interfaces = response.data.interface_stats?.interfaces ?? [];
+            } catch(e) {
+                // do nothing if failed to load interface stats
+                console.log(e);
+            }
+        },
+        formatBytes(bytes) {
+            return Utils.formatBytes(bytes ?? 0);
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/ToolsPage.vue
+++ b/src/frontend/components/tools/ToolsPage.vue
@@ -26,6 +26,44 @@
                 </div>
             </RouterLink>
 
+            <!-- path lookup -->
+            <RouterLink :to="{ name: 'path-lookup' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path fill-rule="evenodd" d="M8.161 2.58a1.875 1.875 0 0 1 1.678 0l4.993 2.498c.106.052.23.052.336 0l3.869-1.935A1.875 1.875 0 0 1 21.75 4.82v12.485c0 .71-.401 1.36-1.037 1.677l-4.875 2.437a1.875 1.875 0 0 1-1.676 0l-4.994-2.497a.375.375 0 0 0-.336 0l-3.868 1.935A1.875 1.875 0 0 1 2.25 19.18V6.695c0-.71.401-1.36 1.036-1.677l4.875-2.437ZM9 6a.75.75 0 0 1 .75.75V15a.75.75 0 0 1-1.5 0V6.75A.75.75 0 0 1 9 6Zm6.75 3a.75.75 0 0 0-1.5 0v8.25a.75.75 0 0 0 1.5 0V9Z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Path Lookup</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Check if a path to a destination is known, its hop count, and which interface it uses.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
+            <!-- live activity -->
+            <RouterLink :to="{ name: 'rf-activity' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path d="M3.53 2.47a.75.75 0 0 0-1.06 1.06 18.72 18.72 0 0 0 0 16.94.75.75 0 1 0 1.34-.68 17.22 17.22 0 0 1 0-15.58.75.75 0 0 0-.28-1.02v.28ZM20.47 2.47a.75.75 0 0 1 1.06 1.06 18.72 18.72 0 0 1 0 16.94.75.75 0 1 1-1.34-.68 17.22 17.22 0 0 0 0-15.58.75.75 0 0 1 .28-1.02v.28Z" />
+                        <path d="M6.7 5.65a.75.75 0 1 0-1.3-.75 14.22 14.22 0 0 0 0 14.2.75.75 0 0 0 1.3-.75 12.72 12.72 0 0 1 0-12.7ZM18.6 4.9a.75.75 0 1 0-1.3.75 12.72 12.72 0 0 1 0 12.7.75.75 0 0 0 1.3.75 14.22 14.22 0 0 0 0-14.2Z" />
+                        <path d="M12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Live Activity</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Watch announces arrive in real time with signal readings, and monitor interface traffic.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
         </div>
     </div>
 </template>

--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -77,6 +77,16 @@ const router = createRouter({
             component: defineAsyncComponent(() => import("./components/ping/PingPage.vue")),
         },
         {
+            name: "path-lookup",
+            path: '/path-lookup',
+            component: defineAsyncComponent(() => import("./components/tools/PathLookupPage.vue")),
+        },
+        {
+            name: "rf-activity",
+            path: '/rf-activity',
+            component: defineAsyncComponent(() => import("./components/tools/RfActivityPage.vue")),
+        },
+        {
             name: "profile.icon",
             path: '/profile/icon',
             component: defineAsyncComponent(() => import("./components/profile/ProfileIconPage.vue")),


### PR DESCRIPTION
Two new tools on the Diagnostics page, both pure frontend over existing endpoints.

Path Lookup: enter a destination hash and see whether a path is known, hop count, next hop, and which interface traffic leaves on. A second button requests the path from the network and waits. This is rnpath in the UI. A note explains Reticulum only reveals the next hop, never the full route.

Live Activity: per interface RX/TX byte counters refreshing every two seconds, plus a real time feed of announces as they arrive over the existing websocket. Entries heard over radio get an RF badge with RSSI, SNR and quality. Very useful when setting up RNode hardware, since it answers whether the radio is actually hearing anything at a glance. The feed is capped at 200 entries and the page costs nothing when closed.

Tested against a live instance with an RNode and TCP interfaces, screenshots verified in both populated and empty states.