### PR TITLE
Add a right click context menu for text fields

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, dialog, ipcMain, shell, systemPreferences } = require('electron');
+const { app, BrowserWindow, dialog, ipcMain, shell, systemPreferences, Menu } = require('electron');
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('node:path');
@@ -247,6 +247,19 @@ app.whenReady().then(async () => {
                 // used to inject logging over ipc
                 preload: path.join(__dirname, 'preload.js'),
             },
+        });
+
+        // show a native right click menu, electron has none by default so paste into inputs was impossible
+        mainWindow.webContents.on('context-menu', (event, params) => {
+            const menuItems = [];
+            if(params.isEditable){
+                menuItems.push({ role: 'cut' }, { role: 'copy' }, { role: 'paste' });
+            } else if(params.selectionText){
+                menuItems.push({ role: 'copy' });
+            }
+            if(menuItems.length > 0){
+                Menu.buildFromTemplate(menuItems).popup();
+            }
         });
 
         // open external links in default web browser instead of electron


### PR DESCRIPTION
Electron windows ship with no context menu at all, so right click paste into any input in the app was impossible. Only keyboard shortcuts worked, which is easy to miss and awkward when pasting destination hashes.

Adds a native context menu on the main window: Cut, Copy and Paste when right clicking an editable field, Copy when right clicking selected text elsewhere, and no menu on non-editable areas with nothing selected.

Tested on a Linux desktop build: paste into text and number inputs works, copy from message text works, external link handling and normal clicking are unchanged.