### PR TITLE
Add path table, propagation sync, hash inspector and log viewer tools

### DIFF
--- a/crosstalk.py
+++ b/crosstalk.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import threading
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, List
@@ -266,6 +267,15 @@ class Crosstalk:
          .where(database.LxmfMessage.state == "outbound")
          .orwhere((database.LxmfMessage.state == "sent") & (database.LxmfMessage.method == "opportunistic"))
          .orwhere(database.LxmfMessage.state == "sending").execute())
+
+        # keep recent rns log lines in memory for the log viewer
+        # the callback still prints, so stdout logging keeps working as before
+        self.log_buffer = deque(maxlen=500)
+        def log_to_buffer(logstring):
+            self.log_buffer.append(logstring)
+            print(logstring)
+        RNS.logdest = RNS.LOG_CALLBACK
+        RNS.logcall = log_to_buffer
 
         # init reticulum
         ensure_bundled_reticulum_interfaces(reticulum_config_dir)
@@ -2199,6 +2209,65 @@ class Crosstalk:
             })
 
         # get Reticulum infrastructure discovered from signed interface advertisements
+        # serve recent rns log lines
+        @routes.get("/api/v1/logs")
+        async def index(request):
+            return web.json_response({
+                "logs": list(self.log_buffer),
+            })
+
+        # serve everything known about a destination hash
+        @routes.get("/api/v1/destination/{destination_hash}/info")
+        async def index(request):
+
+            # get path params
+            destination_hash = request.match_info.get("destination_hash", "")
+
+            # validate destination hash
+            try:
+                destination_hash_bytes = bytes.fromhex(destination_hash)
+            except ValueError:
+                return web.json_response({
+                    "message": "destination_hash is invalid",
+                }, status=422)
+
+            # find announce info, if we have heard this destination announce
+            announce_info = None
+            announce = database.Announce.get_or_none(database.Announce.destination_hash == destination_hash)
+            if announce is not None:
+                display_name = None
+                if announce.aspect == "lxmf.delivery":
+                    display_name = self.parse_lxmf_display_name(announce.app_data, default_value=None)
+                elif announce.aspect == "nomadnetwork.node":
+                    display_name = self.parse_nomadnetwork_node_display_name(announce.app_data, default_value=None)
+                announce_info = {
+                    "aspect": announce.aspect,
+                    "display_name": display_name,
+                    "identity_hash": announce.identity_hash,
+                    "rssi": announce.rssi,
+                    "snr": announce.snr,
+                    "quality": announce.quality,
+                    "last_announced_at": str(announce.updated_at),
+                }
+
+            # find path info, if a path is known
+            path_info = None
+            if RNS.Transport.has_path(destination_hash_bytes):
+                path_info = {
+                    "hops": RNS.Transport.hops_to(destination_hash_bytes),
+                    "next_hop_interface": self.reticulum.get_next_hop_if_name(destination_hash_bytes),
+                }
+
+            return web.json_response({
+                "destination_info": {
+                    "destination_hash": destination_hash,
+                    "custom_display_name": self.get_custom_destination_display_name(destination_hash),
+                    "is_blocked": database.BlockedDestination.get_or_none(database.BlockedDestination.destination_hash == destination_hash) is not None,
+                    "announce": announce_info,
+                    "path": path_info,
+                },
+            })
+
         # clear cached network data so discover and the map only show what is heard on current interfaces
         @routes.post("/api/v1/network-caches/clear")
         async def index(request):

--- a/src/frontend/components/tools/HashInspectorPage.vue
+++ b/src/frontend/components/tools/HashInspectorPage.vue
@@ -1,0 +1,78 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Hash Inspector</div>
+                <div class="text-sm text-[var(--ct-dim)]">Paste any destination hash to see everything this node knows about it.</div>
+                </div>
+            </div>
+
+            <!-- input -->
+            <div class="ct-card p-2.5 space-y-2">
+                <div class="text-sm font-medium text-[var(--ct-text)]">Destination Hash</div>
+                <input v-model="destinationHash" type="text" placeholder="e.g: a39610c89d18bb48c73e429582423c24" class="ct-hash block w-full rounded-lg border p-2.5" @keyup.enter="inspect">
+                <button @click="inspect" :disabled="!cleanedDestinationHash" type="button" class="ct-brand-button rounded-lg px-2.5 py-1.5 text-sm font-semibold disabled:opacity-50">Inspect</button>
+            </div>
+
+            <!-- result -->
+            <div v-if="info" class="ct-card">
+                <div class="flex border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">Result</div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+
+                    <div class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Display Name</span><span>{{ info.announce?.display_name ?? "unknown" }}<span v-if="info.custom_display_name"> (saved as {{ info.custom_display_name }})</span></span></div>
+                    <div class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Blocked</span><span>{{ info.is_blocked ? "yes" : "no" }}</span></div>
+
+                    <template v-if="info.announce">
+                        <div class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Aspect</span><span>{{ info.announce.aspect }}</span></div>
+                        <div class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Identity Hash</span><span class="ct-hash break-all">{{ info.announce.identity_hash }}</span></div>
+                        <div class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Last Announced</span><span>{{ info.announce.last_announced_at }}</span></div>
+                        <div v-if="info.announce.rssi != null" class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Signal</span><span>RSSI {{ info.announce.rssi }}dBm<span v-if="info.announce.snr != null">, SNR {{ info.announce.snr }}dB</span><span v-if="info.announce.quality != null">, Quality {{ info.announce.quality }}%</span></span></div>
+                    </template>
+                    <div v-else class="p-2.5">Never heard an announce from this destination.</div>
+
+                    <div v-if="info.path" class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Path</span><span>{{ info.path.hops }} {{ info.path.hops === 1 ? "hop" : "hops" }} via {{ info.path.next_hop_interface }}</span></div>
+                    <div v-else class="flex p-2.5"><span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Path</span><span>no path known</span></div>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'HashInspectorPage',
+    data() {
+        return {
+            destinationHash: "",
+            info: null,
+        };
+    },
+    computed: {
+        cleanedDestinationHash() {
+            // strip whitespace and angle brackets so pasted "<hash>" values work
+            return this.destinationHash.replace(/[<>\s]/g, "");
+        },
+    },
+    methods: {
+        async inspect() {
+            this.info = null;
+            try {
+                const response = await window.axios.get(`/api/v1/destination/${this.cleanedDestinationHash}/info`);
+                this.info = response.data.destination_info;
+            } catch(e) {
+                console.log(e);
+            }
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/LogViewerPage.vue
+++ b/src/frontend/components/tools/LogViewerPage.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Log Viewer</div>
+                <div class="text-sm text-[var(--ct-dim)]">Recent Reticulum log output. Useful for diagnosing interface problems, sync activity and delivery issues without a terminal.</div>
+                </div>
+            </div>
+
+            <!-- logs -->
+            <div class="ct-card">
+                <div class="flex items-center gap-x-2.5 border-b border-[var(--ct-border)] p-2.5">
+                    <span class="mr-auto font-semibold text-[var(--ct-text)]">{{ filteredLogs.length }}<span v-if="searchText"> of {{ logs.length }}</span> lines</span>
+                    <input v-model="searchText" type="text" placeholder="Search logs..." class="rounded-lg border p-1.5 text-sm">
+                    <label class="flex cursor-pointer items-center gap-x-1.5 text-sm text-[var(--ct-dim)]">
+                        <input v-model="autoRefresh" type="checkbox" class="size-4 rounded border">
+                        Auto refresh
+                    </label>
+                </div>
+                <div class="max-h-[70vh] overflow-y-auto p-2.5">
+                    <div v-if="filteredLogs.length === 0" class="text-sm text-[var(--ct-dim)]">{{ searchText ? "No log lines match your search." : "No log lines yet." }}</div>
+                    <div v-for="(line, index) in filteredLogs" :key="index" class="ct-hash whitespace-pre-wrap break-all border-b border-[var(--ct-border)] py-0.5 text-xs text-[var(--ct-muted)] last:border-b-0">{{ line }}</div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'LogViewerPage',
+    data() {
+        return {
+            logs: [],
+            searchText: "",
+            autoRefresh: true,
+            refreshInterval: null,
+        };
+    },
+    computed: {
+        filteredLogs() {
+            // newest lines first, filtered by search text
+            const search = this.searchText.toLowerCase().trim();
+            const reversed = [...this.logs].reverse();
+            if(!search){
+                return reversed;
+            }
+            return reversed.filter((line) => line.toLowerCase().includes(search));
+        },
+    },
+    mounted() {
+        this.getLogs();
+        this.refreshInterval = setInterval(() => {
+            if(this.autoRefresh){
+                this.getLogs();
+            }
+        }, 2000);
+    },
+    beforeUnmount() {
+        clearInterval(this.refreshInterval);
+    },
+    methods: {
+        async getLogs() {
+            try {
+                const response = await window.axios.get("/api/v1/logs");
+                this.logs = response.data.logs;
+            } catch(e) {
+                console.log(e);
+            }
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/LogViewerPage.vue
+++ b/src/frontend/components/tools/LogViewerPage.vue
@@ -21,13 +21,17 @@
                     <span class="mr-auto font-semibold text-[var(--ct-text)]">{{ filteredLogs.length }}<span v-if="searchText"> of {{ logs.length }}</span> lines</span>
                     <input v-model="searchText" type="text" placeholder="Search logs..." class="rounded-lg border p-1.5 text-sm">
                     <label class="flex cursor-pointer items-center gap-x-1.5 text-sm text-[var(--ct-dim)]">
+                        <input v-model="colorize" type="checkbox" class="size-4 rounded border">
+                        Color by level
+                    </label>
+                    <label class="flex cursor-pointer items-center gap-x-1.5 text-sm text-[var(--ct-dim)]">
                         <input v-model="autoRefresh" type="checkbox" class="size-4 rounded border">
                         Auto refresh
                     </label>
                 </div>
                 <div class="max-h-[70vh] overflow-y-auto p-2.5">
                     <div v-if="filteredLogs.length === 0" class="text-sm text-[var(--ct-dim)]">{{ searchText ? "No log lines match your search." : "No log lines yet." }}</div>
-                    <div v-for="(line, index) in filteredLogs" :key="index" class="ct-hash whitespace-pre-wrap break-all border-b border-[var(--ct-border)] py-0.5 text-xs text-[var(--ct-muted)] last:border-b-0">{{ line }}</div>
+                    <div v-for="(line, index) in filteredLogs" :key="index" class="ct-hash whitespace-pre-wrap break-all border-b border-[var(--ct-border)] py-0.5 text-xs last:border-b-0" :class="colorize ? levelClass(line) : 'text-[var(--ct-muted)]'">{{ line }}</div>
                 </div>
             </div>
 
@@ -42,6 +46,7 @@ export default {
         return {
             logs: [],
             searchText: "",
+            colorize: true,
             autoRefresh: true,
             refreshInterval: null,
         };
@@ -69,6 +74,19 @@ export default {
         clearInterval(this.refreshInterval);
     },
     methods: {
+        levelClass(line) {
+            // rns log lines carry their level like "[2026-09-01 12:00:00] [Error] ..."
+            if(line.includes("[Critical]") || line.includes("[Error]")){
+                return "text-red-400";
+            }
+            if(line.includes("[Warning]")){
+                return "text-amber-400";
+            }
+            if(line.includes("[Verbose]") || line.includes("[Debug]") || line.includes("[Extreme]")){
+                return "text-[var(--ct-dim)]";
+            }
+            return "text-[var(--ct-muted)]";
+        },
         async getLogs() {
             try {
                 const response = await window.axios.get("/api/v1/logs");

--- a/src/frontend/components/tools/LogViewerPage.vue
+++ b/src/frontend/components/tools/LogViewerPage.vue
@@ -31,7 +31,7 @@
                 </div>
                 <div class="max-h-[70vh] overflow-y-auto p-2.5">
                     <div v-if="filteredLogs.length === 0" class="text-sm text-[var(--ct-dim)]">{{ searchText ? "No log lines match your search." : "No log lines yet." }}</div>
-                    <div v-for="(line, index) in filteredLogs" :key="index" class="ct-hash whitespace-pre-wrap break-all border-b border-[var(--ct-border)] py-0.5 text-xs last:border-b-0" :class="colorize ? levelClass(line) : 'text-[var(--ct-muted)]'">{{ line }}</div>
+                    <div v-for="(line, index) in filteredLogs" :key="index" class="ct-hash whitespace-pre-wrap break-all border-b border-[var(--ct-border)] py-0.5 text-xs text-[var(--ct-muted)] last:border-b-0" :style="colorize ? levelStyle(line) : null">{{ line }}</div>
                 </div>
             </div>
 
@@ -74,18 +74,19 @@ export default {
         clearInterval(this.refreshInterval);
     },
     methods: {
-        levelClass(line) {
+        levelStyle(line) {
             // rns log lines carry their level like "[2026-09-01 12:00:00] [Error] ..."
+            // inline style so the colors are not overridden by the ct-hash class
             if(line.includes("[Critical]") || line.includes("[Error]")){
-                return "text-red-400";
+                return { color: "#f87171" };
             }
             if(line.includes("[Warning]")){
-                return "text-amber-400";
+                return { color: "#fbbf24" };
             }
             if(line.includes("[Verbose]") || line.includes("[Debug]") || line.includes("[Extreme]")){
-                return "text-[var(--ct-dim)]";
+                return { color: "var(--ct-dim)" };
             }
-            return "text-[var(--ct-muted)]";
+            return null;
         },
         async getLogs() {
             try {

--- a/src/frontend/components/tools/PathLookupPage.vue
+++ b/src/frontend/components/tools/PathLookupPage.vue
@@ -3,9 +3,16 @@
         <div class="overflow-y-auto space-y-3 p-3">
 
             <!-- page header -->
-            <div>
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
                 <div class="text-lg font-bold text-[var(--ct-text)]">Path Lookup</div>
                 <div class="text-sm text-[var(--ct-dim)]">See if a path to a destination is known, how many hops away it is, and which interface traffic will leave on. Reticulum only reveals the next hop, never the full route.</div>
+                </div>
             </div>
 
             <!-- lookup form -->

--- a/src/frontend/components/tools/PathTablePage.vue
+++ b/src/frontend/components/tools/PathTablePage.vue
@@ -1,0 +1,113 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Path Table</div>
+                <div class="text-sm text-[var(--ct-dim)]">Every destination this node currently knows a route to, how many hops away it is, and which interface it routes via. Drop a path to force it to be rediscovered.</div>
+                </div>
+            </div>
+
+            <!-- table -->
+            <div class="ct-card">
+                <div class="flex items-center gap-x-2.5 border-b border-[var(--ct-border)] p-2.5">
+                    <span class="mr-auto font-semibold text-[var(--ct-text)]">{{ filteredEntries.length }} paths</span>
+                    <input v-model="searchText" type="text" placeholder="Filter by name or hash..." class="rounded-lg border p-1.5 text-sm">
+                    <button @click="getPathTable" type="button" class="ct-secondary-button rounded-lg px-2.5 py-1.5 text-sm font-semibold">Refresh</button>
+                </div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+                    <div v-if="filteredEntries.length === 0" class="p-2.5 text-[var(--ct-dim)]">No paths known. Paths appear as announces are received.</div>
+                    <div v-for="entry in filteredEntries" :key="entry.destination_hash" class="flex items-center gap-x-2.5 p-2.5">
+                        <div class="min-w-0 mr-auto">
+                            <div class="truncate font-medium text-[var(--ct-text)]">{{ entry.display_name ?? "Unknown" }}<span v-if="entry.aspect" class="ml-2 text-xs font-normal text-[var(--ct-dim)]">{{ entry.aspect }}</span></div>
+                            <div class="ct-hash truncate text-xs text-[var(--ct-dim)]">{{ entry.destination_hash }}</div>
+                        </div>
+                        <span class="shrink-0 text-xs">{{ entry.hops }} {{ entry.hops === 1 ? "hop" : "hops" }}</span>
+                        <span class="shrink-0 max-w-48 truncate text-xs text-[var(--ct-dim)]" :title="entry.interface">{{ entry.interface }}</span>
+                        <button @click="dropPath(entry)" type="button" class="ct-secondary-button shrink-0 rounded-lg px-2 py-1 text-xs font-semibold">Drop</button>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+import DialogUtils from "../../js/DialogUtils";
+
+export default {
+    name: 'PathTablePage',
+    data() {
+        return {
+            entries: [],
+            searchText: "",
+        };
+    },
+    computed: {
+        filteredEntries() {
+            const search = this.searchText.toLowerCase().trim();
+            if(!search){
+                return this.entries;
+            }
+            return this.entries.filter((entry) => {
+                return entry.destination_hash.includes(search)
+                    || (entry.display_name ?? "").toLowerCase().includes(search)
+                    || (entry.interface ?? "").toLowerCase().includes(search);
+            });
+        },
+    },
+    mounted() {
+        this.getPathTable();
+    },
+    methods: {
+        async getPathTable() {
+            try {
+
+                // fetch path table and announces, so we can show recognisable names for known destinations
+                const [pathTableResponse, announcesResponse] = await Promise.all([
+                    window.axios.get("/api/v1/path-table"),
+                    window.axios.get("/api/v1/announces"),
+                ]);
+
+                // map announces by destination hash
+                const announces = {};
+                for(const announce of announcesResponse.data.announces){
+                    announces[announce.destination_hash] = announce;
+                }
+
+                // join announce info onto path table entries, nearest destinations first
+                this.entries = pathTableResponse.data.path_table.map((entry) => {
+                    const announce = announces[entry.hash];
+                    return {
+                        destination_hash: entry.hash,
+                        display_name: announce?.display_name ?? null,
+                        aspect: announce?.aspect ?? null,
+                        hops: entry.hops,
+                        interface: entry.interface,
+                    };
+                }).sort((a, b) => a.hops - b.hops || a.destination_hash.localeCompare(b.destination_hash));
+
+            } catch(e) {
+                console.log(e);
+            }
+        },
+        async dropPath(entry) {
+            try {
+                await window.axios.post(`/api/v1/destination/${entry.destination_hash}/drop-path`);
+                await this.getPathTable();
+            } catch(e) {
+                DialogUtils.toast("Failed to drop path", "error");
+                console.log(e);
+            }
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/PropagationHealthPage.vue
+++ b/src/frontend/components/tools/PropagationHealthPage.vue
@@ -1,0 +1,170 @@
+<template>
+    <div class="flex flex-col flex-1 overflow-hidden min-w-full sm:min-w-[500px]">
+        <div class="overflow-y-auto space-y-3 p-3">
+
+            <!-- page header -->
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
+                <div class="text-lg font-bold text-[var(--ct-text)]">Propagation Sync</div>
+                <div class="text-sm text-[var(--ct-dim)]">Health of message syncing with your preferred propagation node, which stores messages for you while you are offline.</div>
+                </div>
+            </div>
+
+            <!-- health card -->
+            <div class="ct-card">
+                <div class="flex items-center border-b border-[var(--ct-border)] p-2.5">
+                    <span class="mr-auto font-semibold text-[var(--ct-text)]">Status</span>
+                    <button @click="syncNow" type="button" class="ct-brand-button rounded-lg px-2.5 py-1.5 text-sm font-semibold">Sync Now</button>
+                </div>
+                <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
+
+                    <div v-if="!preferredNode" class="p-2.5">
+                        No preferred propagation node is configured. Set one in Settings, or browse propagation nodes to pick one.
+                    </div>
+
+                    <template v-else>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Preferred Node</span>
+                            <span><span v-if="nodeDisplayName">{{ nodeDisplayName }} </span><span class="ct-hash break-all">{{ preferredNode }}</span></span>
+                        </div>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Path to Node</span>
+                            <span>{{ nodePath === null ? "checking..." : (nodePath.path ? `${nodePath.path.hops} ${nodePath.path.hops === 1 ? "hop" : "hops"} via ${nodePath.path.next_hop_interface}` : "no path known") }}</span>
+                        </div>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Sync State</span>
+                            <span>{{ status?.state ?? "unknown" }}<span v-if="status && status.state !== 'idle' && status.progress > 0"> ({{ status.progress.toFixed(0) }}%)</span></span>
+                        </div>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Last Synced</span>
+                            <span>{{ lastSyncedText }}</span>
+                        </div>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Messages Last Sync</span>
+                            <span>{{ status?.messages_received ?? "none" }}</span>
+                        </div>
+                        <div class="flex p-2.5">
+                            <span class="w-44 shrink-0 font-medium text-[var(--ct-text)]">Auto Sync</span>
+                            <span>{{ autoSyncText }}<span v-if="nextSyncText">, next {{ nextSyncText }}</span></span>
+                        </div>
+                    </template>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>
+
+<script>
+import Utils from "../../js/Utils";
+import DialogUtils from "../../js/DialogUtils";
+
+export default {
+    name: 'PropagationHealthPage',
+    data() {
+        return {
+            config: null,
+            status: null,
+            nodePath: null,
+            nodeDisplayName: null,
+            statusInterval: null,
+        };
+    },
+    computed: {
+        preferredNode() {
+            return this.config?.lxmf_preferred_propagation_node_destination_hash;
+        },
+        lastSyncedText() {
+            const lastSyncedAt = this.config?.lxmf_preferred_propagation_node_last_synced_at;
+            return lastSyncedAt ? Utils.formatSecondsAgo(lastSyncedAt) : "never";
+        },
+        autoSyncText() {
+            const seconds = parseInt(this.config?.lxmf_preferred_propagation_node_auto_sync_interval_seconds ?? 0);
+            if(!seconds){
+                return "disabled";
+            }
+            const minutes = Math.round(seconds / 60);
+            return minutes >= 60 ? `every ${minutes / 60} ${minutes === 60 ? "hour" : "hours"}` : `every ${minutes} minutes`;
+        },
+        nextSyncText() {
+            const intervalSeconds = parseInt(this.config?.lxmf_preferred_propagation_node_auto_sync_interval_seconds ?? 0);
+            const lastSyncedAt = this.config?.lxmf_preferred_propagation_node_last_synced_at;
+            if(!intervalSeconds || !lastSyncedAt){
+                return null;
+            }
+            const secondsUntil = (lastSyncedAt + intervalSeconds) - Math.floor(Date.now() / 1000);
+            if(secondsUntil <= 0){
+                return "due now";
+            }
+            const minutesUntil = Math.ceil(secondsUntil / 60);
+            return `in ${minutesUntil} ${minutesUntil === 1 ? "minute" : "minutes"}`;
+        },
+    },
+    mounted() {
+        this.getConfig();
+        this.getStatus();
+        this.statusInterval = setInterval(() => {
+            this.getStatus();
+            this.getConfig();
+        }, 2000);
+    },
+    beforeUnmount() {
+        clearInterval(this.statusInterval);
+    },
+    methods: {
+        async getConfig() {
+            try {
+                const response = await window.axios.get("/api/v1/config");
+                this.config = response.data.config;
+                // check path and display name for the preferred node once we know it
+                if(this.preferredNode && this.nodePath === null){
+                    this.getNodePath();
+                    this.getNodeDisplayName();
+                }
+            } catch(e) {
+                console.log(e);
+            }
+        },
+        async getStatus() {
+            try {
+                const response = await window.axios.get("/api/v1/lxmf/propagation-node/status");
+                this.status = response.data.propagation_node_status;
+            } catch(e) {
+                console.log(e);
+            }
+        },
+        async getNodePath() {
+            try {
+                const response = await window.axios.get(`/api/v1/destination/${this.preferredNode}/path`);
+                this.nodePath = response.data;
+            } catch(e) {
+                this.nodePath = { path: null };
+                console.log(e);
+            }
+        },
+        async getNodeDisplayName() {
+            try {
+                const response = await window.axios.get(`/api/v1/destination/${this.preferredNode}/info`);
+                this.nodeDisplayName = response.data.destination_info.announce?.display_name ?? null;
+            } catch(e) {
+                console.log(e);
+            }
+        },
+        async syncNow() {
+            try {
+                await window.axios.get("/api/v1/lxmf/propagation-node/sync");
+                DialogUtils.toast("Sync started");
+            } catch(e) {
+                DialogUtils.toast("Failed to start sync", "error");
+                console.log(e);
+            }
+        },
+    },
+}
+</script>

--- a/src/frontend/components/tools/RfActivityPage.vue
+++ b/src/frontend/components/tools/RfActivityPage.vue
@@ -33,15 +33,16 @@
 
             <!-- announce feed -->
             <div class="ct-card">
-                <div class="flex items-center border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">
+                <div class="flex items-center gap-x-2.5 border-b border-[var(--ct-border)] p-2.5 font-semibold text-[var(--ct-text)]">
                     <span class="mr-auto">Announces</span>
-                    <span class="text-sm font-normal text-[var(--ct-dim)]">{{ announces.length }} heard since opening</span>
+                    <input v-model="searchText" type="text" placeholder="Filter by name or hash..." class="rounded-lg border p-1.5 text-sm font-normal">
+                    <span class="text-sm font-normal text-[var(--ct-dim)]">{{ searchText ? `${filteredAnnounces.length} of ${announces.length}` : announces.length }} heard since opening</span>
                 </div>
                 <div class="divide-y divide-[var(--ct-border)] text-sm text-[var(--ct-muted)]">
-                    <div v-if="announces.length === 0" class="p-2.5 text-[var(--ct-dim)]">
-                        No announces heard since opening this page. A TCP hub can still show RX growth from path requests. Ask a peer to announce, or wait — peers often re-announce only every few hours.
+                    <div v-if="filteredAnnounces.length === 0" class="p-2.5 text-[var(--ct-dim)]">
+                        {{ searchText ? "No announces match your filter." : "No announces heard since opening this page. A TCP hub can still show RX growth from path requests. Ask a peer to announce, or wait — peers often re-announce only every few hours." }}
                     </div>
-                    <div v-for="announce in announces" :key="announce.key" class="p-2.5">
+                    <div v-for="announce in filteredAnnounces" :key="announce.key" class="p-2.5">
                         <div class="flex items-center gap-x-2">
                             <span v-if="announce.origin === 'sent'" class="shrink-0 rounded bg-[rgba(0,97,253,0.15)] px-1.5 py-0.5 text-xs font-semibold text-[#7db0ff]">Sent</span>
                             <span v-else-if="announce.rssi != null" class="shrink-0 rounded bg-[rgba(46,231,129,0.15)] px-1.5 py-0.5 text-xs font-semibold text-[var(--ct-green)]">RF</span>
@@ -75,8 +76,22 @@ export default {
         return {
             announces: [],
             interfaces: [],
+            searchText: "",
             statsInterval: null,
         };
+    },
+    computed: {
+        filteredAnnounces() {
+            const search = this.searchText.toLowerCase().trim();
+            if(!search){
+                return this.announces;
+            }
+            return this.announces.filter((announce) => {
+                return (announce.destination_hash ?? "").includes(search)
+                    || (announce.display_name ?? "").toLowerCase().includes(search)
+                    || (announce.aspect ?? "").toLowerCase().includes(search);
+            });
+        },
     },
     mounted() {
         WebSocketConnection.on("message", this.onWebsocketMessage);

--- a/src/frontend/components/tools/RfActivityPage.vue
+++ b/src/frontend/components/tools/RfActivityPage.vue
@@ -3,9 +3,16 @@
         <div class="overflow-y-auto space-y-3 p-3">
 
             <!-- page header -->
-            <div>
+            <div class="flex items-center gap-x-2">
+                <RouterLink :to="{ name: 'tools' }" class="flex rounded-md p-1.5 text-[var(--ct-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--ct-text)]" title="Back to Diagnostics">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+                    </svg>
+                </RouterLink>
+                <div>
                 <div class="text-lg font-bold text-[var(--ct-text)]">Live Activity</div>
                 <div class="text-sm text-[var(--ct-dim)]">Watch traffic on your interfaces. Path requests keep a hub busy even when nobody is announcing. Announces appear here as they are heard, including rebroadcasts of destinations you already know.</div>
+                </div>
             </div>
 
             <!-- interfaces -->

--- a/src/frontend/components/tools/ToolsPage.vue
+++ b/src/frontend/components/tools/ToolsPage.vue
@@ -26,16 +26,18 @@
                 </div>
             </RouterLink>
 
-            <!-- path lookup -->
-            <RouterLink :to="{ name: 'path-lookup' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+
+
+            <!-- propagation sync -->
+            <RouterLink :to="{ name: 'propagation-health' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
                 <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
-                        <path fill-rule="evenodd" d="M8.161 2.58a1.875 1.875 0 0 1 1.678 0l4.993 2.498c.106.052.23.052.336 0l3.869-1.935A1.875 1.875 0 0 1 21.75 4.82v12.485c0 .71-.401 1.36-1.037 1.677l-4.875 2.437a1.875 1.875 0 0 1-1.676 0l-4.994-2.497a.375.375 0 0 0-.336 0l-3.868 1.935A1.875 1.875 0 0 1 2.25 19.18V6.695c0-.71.401-1.36 1.036-1.677l4.875-2.437ZM9 6a.75.75 0 0 1 .75.75V15a.75.75 0 0 1-1.5 0V6.75A.75.75 0 0 1 9 6Zm6.75 3a.75.75 0 0 0-1.5 0v8.25a.75.75 0 0 0 1.5 0V9Z" clip-rule="evenodd" />
+                        <path fill-rule="evenodd" d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" clip-rule="evenodd" />
                     </svg>
                 </div>
                 <div class="my-auto mr-auto">
-                    <div class="font-bold text-[var(--ct-text)]">Path Lookup</div>
-                    <div class="text-sm text-[var(--ct-dim)]">Check if a path to a destination is known, its hop count, and which interface it uses.</div>
+                    <div class="font-bold text-[var(--ct-text)]">Propagation Sync</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Health of message syncing with your preferred propagation node, and a manual sync trigger.</div>
                 </div>
                 <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
@@ -43,6 +45,7 @@
                     </svg>
                 </div>
             </RouterLink>
+
 
             <!-- live activity -->
             <RouterLink :to="{ name: 'rf-activity' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
@@ -64,6 +67,86 @@
                 </div>
             </RouterLink>
 
+            <!-- advanced tools -->
+            <button @click="showAdvanced = !showAdvanced" type="button" class="flex w-full items-center gap-x-1.5 px-1 text-sm font-semibold text-[var(--ct-dim)] hover:text-[var(--ct-text)]">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-4 transition-transform" :class="{ 'rotate-90': showAdvanced }">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                </svg>
+                Advanced
+            </button>
+
+
+            <!-- path lookup -->
+            <RouterLink v-if="showAdvanced" :to="{ name: 'path-lookup' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path fill-rule="evenodd" d="M8.161 2.58a1.875 1.875 0 0 1 1.678 0l4.993 2.498c.106.052.23.052.336 0l3.869-1.935A1.875 1.875 0 0 1 21.75 4.82v12.485c0 .71-.401 1.36-1.037 1.677l-4.875 2.437a1.875 1.875 0 0 1-1.676 0l-4.994-2.497a.375.375 0 0 0-.336 0l-3.868 1.935A1.875 1.875 0 0 1 2.25 19.18V6.695c0-.71.401-1.36 1.036-1.677l4.875-2.437ZM9 6a.75.75 0 0 1 .75.75V15a.75.75 0 0 1-1.5 0V6.75A.75.75 0 0 1 9 6Zm6.75 3a.75.75 0 0 0-1.5 0v8.25a.75.75 0 0 0 1.5 0V9Z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Path Lookup</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Check if a path to a destination is known, its hop count, and which interface it uses.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
+            <!-- path table -->
+            <RouterLink v-if="showAdvanced" :to="{ name: 'path-table' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path fill-rule="evenodd" d="M2.625 6.75a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Zm4.875 0A.75.75 0 0 1 8.25 6h12a.75.75 0 0 1 0 1.5h-12a.75.75 0 0 1-.75-.75ZM2.625 12a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0ZM7.5 12a.75.75 0 0 1 .75-.75h12a.75.75 0 0 1 0 1.5h-12A.75.75 0 0 1 7.5 12Zm-4.875 5.25a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Zm4.875 0a.75.75 0 0 1 .75-.75h12a.75.75 0 0 1 0 1.5h-12a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Path Table</div>
+                    <div class="text-sm text-[var(--ct-dim)]">All destinations this node knows a route to, and which interface each routes via.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
+            <!-- hash inspector -->
+            <RouterLink v-if="showAdvanced" :to="{ name: 'hash-inspector' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path fill-rule="evenodd" d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Hash Inspector</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Paste any destination hash to see everything this node knows about it.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
+            <RouterLink v-if="showAdvanced" :to="{ name: 'log-viewer' }" class="ct-card ct-card-hover group flex items-center gap-x-3 p-3">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[rgba(0,97,253,0.3)] bg-[rgba(0,97,253,0.1)] text-[#7db0ff]">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                        <path fill-rule="evenodd" d="M2.25 6a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V6Zm3.97.97a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 0 1-1.06-1.06l1.72-1.72-1.72-1.72a.75.75 0 0 1 0-1.06Zm4.28 4.28a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 0-1.5h-3Z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="my-auto mr-auto">
+                    <div class="font-bold text-[var(--ct-text)]">Log Viewer</div>
+                    <div class="text-sm text-[var(--ct-dim)]">Recent Reticulum log output for diagnosing interface, sync and delivery problems.</div>
+                </div>
+                <div class="my-auto text-[var(--ct-dim)] group-hover:text-[var(--ct-text)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                    </svg>
+                </div>
+            </RouterLink>
+
         </div>
     </div>
 </template>
@@ -72,5 +155,10 @@
 
 export default {
     name: 'ToolsPage',
+    data() {
+        return {
+            showAdvanced: false,
+        };
+    },
 }
 </script>

--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -128,6 +128,26 @@ const router = createRouter({
             component: defineAsyncComponent(() => import("./components/tools/RfActivityPage.vue")),
         },
         {
+            name: "path-table",
+            path: '/path-table',
+            component: defineAsyncComponent(() => import("./components/tools/PathTablePage.vue")),
+        },
+        {
+            name: "propagation-health",
+            path: '/propagation-health',
+            component: defineAsyncComponent(() => import("./components/tools/PropagationHealthPage.vue")),
+        },
+        {
+            name: "hash-inspector",
+            path: '/hash-inspector',
+            component: defineAsyncComponent(() => import("./components/tools/HashInspectorPage.vue")),
+        },
+        {
+            name: "log-viewer",
+            path: '/log-viewer',
+            component: defineAsyncComponent(() => import("./components/tools/LogViewerPage.vue")),
+        },
+        {
             name: "profile.icon",
             path: '/profile/icon',
             component: defineAsyncComponent(() => import("./components/profile/ProfileIconPage.vue")),


### PR DESCRIPTION
Four more diagnostics tools building on the path lookup and live activity tools from #16.

Path Table: every destination this node currently knows a route to, with hop count and outgoing interface, joined client side with display names from announces. Each row has a Drop button to force a stale route to be rediscovered, useful on radio links where paths outlive reality. Filterable by name, hash or interface.

Propagation Sync: preferred node with its display name, path to it, live sync state with progress, last synced time, messages received, and the auto sync interval with a countdown to the next sync. Includes a Sync Now button.

Hash Inspector: paste any destination hash and see everything this node knows about it: display name, aspect, identity hash, last announce with signal readings, blocked status and current path. Backed by a new GET /api/v1/destination/{hash}/info endpoint.

Log Viewer: the last 500 Reticulum log lines with text search and auto refresh, for diagnosing interface, sync and delivery problems without a terminal. Backed by a new GET /api/v1/logs endpoint reading an in-memory ring buffer fed by the RNS log callback. Stdout logging is unchanged.

The Diagnostics page keeps Ping, Propagation Sync and Live Activity at the top level and groups the routing and protocol tools (Path Lookup, Path Table, Hash Inspector, Log Viewer) under an Advanced expander. All tool pages get a back link to the Diagnostics list, following the existing Add Interface page convention.

Tested against a live instance with an RNode and TCP interfaces.
